### PR TITLE
Enable backend type(s3) for storing terraform state file

### DIFF
--- a/aws_scale_templates/aws_new_vpc_scale/aws_new_vpc_scale.tf
+++ b/aws_scale_templates/aws_new_vpc_scale/aws_new_vpc_scale.tf
@@ -5,6 +5,10 @@
     3. (Compute, Storage) Instances along with EBS attachments to storage instances
 */
 
+terraform {
+  backend "s3" {}
+}
+
 module "vpc_module" {
   source             = "../sub_modules/vpc_template"
   region             = var.region

--- a/aws_scale_templates/sub_modules/instance_template/aws_scale_instances.tf
+++ b/aws_scale_templates/sub_modules/instance_template/aws_scale_instances.tf
@@ -8,6 +8,10 @@
     Tags are not allowed for EBS, root volumes.
 */
 
+terraform {
+  backend "s3" {}
+}
+
 module "cluster_host_iam_role" {
   source           = "../../../resources/aws/compute/iam/iam_role"
   role_name_prefix = "${var.stack_name}-Cluster-"

--- a/aws_scale_templates/tf_backend/create_tf_state_bucket.tf
+++ b/aws_scale_templates/tf_backend/create_tf_state_bucket.tf
@@ -1,0 +1,44 @@
+/*
+    Creates new AWS s3 bucket which will be used for storing
+    terraform state file.
+*/
+
+variable "region" {
+  /* Keep it empty, it will be propagated via command line or via ".tfvars"
+       or ".tfvars.json"
+    */
+  type        = string
+  description = "AWS region where the resources will be created."
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "Name to be used for bucket (make sure it is unique)"
+}
+
+variable "force_destroy" {
+  type        = bool
+  default     = true
+  description = "Whether to allow a forceful destruction of this bucket"
+}
+
+resource "aws_s3_bucket" "create_bucket" {
+  bucket        = var.bucket_name
+  region        = var.region
+  force_destroy = var.force_destroy
+
+  versioning {
+    enabled = true
+  }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.create_bucket.arn
+}

--- a/aws_scale_templates/tf_backend/create_tf_state_bucket_provider.tf
+++ b/aws_scale_templates/tf_backend/create_tf_state_bucket_provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+provider "aws" {
+  region  = var.region
+  version = "~> 2.0"
+}


### PR DESCRIPTION
This requires README changes;

Step1: Before creating terraform scale resources, one needs to create a bucket (skip if bucket is already available).
```
$ cd ibm-spectrum-scale-cloud-install/aws_scale_templates/tf_backend
$ terraform init
$ terraform apply

(PS: Input bucket_name, region)
```
Step-2: Create a backend configuration file (in case of new vpc, incase of existing vpc same steps are valid, the path would be `ibm-spectrum-scale-cloud-install/aws_scale_templates/sub_modules/instance_template`).
```
$ cd ibm-spectrum-scale-cloud-install/aws_scale_templates/aws_new_vpc_scale
$ echo "bucket         = <bucket_name_created_in_step1" >> s3_backend_config
$ echo "key              = <stack_name>-terraform.tfstate" >>  s3_backend_config
$ echo "region         = <region>" >>  s3_backend_config
$ terraform init -backend-config=s3_backend_config
$ terraform apply
```


Closes #31