### PR TITLE
Updating aws command execution with absolute path

### DIFF
--- a/resources/aws/compute/ec2/create.tf
+++ b/resources/aws/compute/ec2/create.tf
@@ -100,7 +100,7 @@ while [[ $get_priv_key_status -ne 0 && $priv_retry_count -lt $SSM_RETRY_LIMIT ]]
 do
     sleep 20
     echo "INFO: Retrieving instance keys (1)"
-    private_key=$(aws ssm get-parameter --name "${var.private_key_ssm_name}" --region "${var.region}" --with-decryption --query 'Parameter.{Value:Value}' --output text)
+    private_key=$(/usr/local/bin/aws ssm get-parameter --name "${var.private_key_ssm_name}" --region "${var.region}" --with-decryption --query 'Parameter.{Value:Value}' --output text)
     get_priv_key_status=$?
     if [[ $get_priv_key_status -eq 0 ]]
     then
@@ -120,7 +120,7 @@ while [[ $get_pub_key_status -ne 0 && $pub_retry_count -lt $SSM_RETRY_LIMIT ]]
 do
     sleep 20
     echo "INFO: Retrieving instance keys (2)"
-    public_key=$(aws ssm get-parameter --name "${var.public_key_ssm_name}" --region "${var.region}" --with-decryption --query 'Parameter.{Value:Value}' --output text)
+    public_key=$(/usr/local/bin/aws ssm get-parameter --name "${var.public_key_ssm_name}" --region "${var.region}" --with-decryption --query 'Parameter.{Value:Value}' --output text)
     get_pub_key_status=$?
     if [[ $get_pub_key_status -eq 0 ]]
     then

--- a/resources/aws/sns/sns_topic.tf
+++ b/resources/aws/sns/sns_topic.tf
@@ -16,7 +16,7 @@ resource "aws_sns_topic" "email_topic" {
   name = var.sns_topic_name
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = "aws sns subscribe --topic-arn ${aws_sns_topic.email_topic.arn} --protocol email --notification-endpoint ${var.operator_email} --region ${var.region}"
+    command     = "/usr/local/bin/aws sns subscribe --topic-arn ${aws_sns_topic.email_topic.arn} --protocol email --notification-endpoint ${var.operator_email} --region ${var.region}"
   }
 }
 

--- a/resources/aws/ssm/ssm_parameter_store.tf
+++ b/resources/aws/ssm/ssm_parameter_store.tf
@@ -11,7 +11,7 @@ variable "region" {}
 resource "null_resource" "put_ssm_parameter" {
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = "aws ssm put-parameter --name ${var.parameter_name} --value \"`cat ${var.parameter_value}`\" --type ${var.parameter_type} --overwrite --region ${var.region}"
+    command     = "/usr/local/bin/aws ssm put-parameter --name ${var.parameter_name} --value \"`cat ${var.parameter_value}`\" --type ${var.parameter_type} --overwrite --region ${var.region}"
   }
 }
 


### PR DESCRIPTION
If env varibale "PATH" is not set with "/usr/local/bin/" the execution will fail. 
`Output: /bin/bash: aws: command not found`
So updating all the aws commands with full path. 