### PR TITLE
Bug: Additional code to fetch the images ID that are made Public 

### DIFF
--- a/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
@@ -11,6 +11,11 @@ locals {
   scale_version      = regex("gpfs.base-(.*).x86_64.rpm", tolist(local.gpfs_base_rpm_path)[0])[0]
 }
 
+locals {
+  compute_instance_image_id = var.compute_vsi_osimage_id != "" ? var.compute_vsi_osimage_id : data.ibm_is_image.compute_instance_image.id
+  storage_instance_image_id = var.storage_vsi_osimage_id != "" ? var.storage_vsi_osimage_id : data.ibm_is_image.storage_instance_image.id
+}
+
 module "generate_compute_cluster_keys" {
   source  = "../../../resources/common/generate_keys"
   turn_on = var.total_compute_cluster_instances > 0 ? true : false
@@ -141,7 +146,7 @@ module "compute_cluster_instances" {
   vpc_id               = var.vpc_id
   resource_group_id    = var.resource_group_id
   zones                = [var.vpc_availability_zones[0]]
-  vsi_image_id         = data.ibm_is_image.compute_instance_image.id
+  vsi_image_id         = local.compute_instance_image_id
   vsi_profile          = var.compute_vsi_profile
   dns_domain           = var.vpc_compute_cluster_dns_domain
   dns_service_id       = var.vpc_compute_cluster_dns_service_id
@@ -173,7 +178,7 @@ module "storage_cluster_instances" {
   vpc_id               = var.vpc_id
   resource_group_id    = var.resource_group_id
   zones                = [var.vpc_availability_zones[0]]
-  vsi_image_id         = data.ibm_is_image.storage_instance_image.id
+  vsi_image_id         = local.storage_instance_image_id
   vsi_profile          = var.storage_vsi_profile
   dns_domain           = var.vpc_storage_cluster_dns_domain
   dns_service_id       = var.vpc_storage_cluster_dns_service_id

--- a/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
@@ -12,8 +12,8 @@ locals {
 }
 
 locals {
-  compute_instance_image_id = var.compute_vsi_osimage_id != "" ? var.compute_vsi_osimage_id : data.ibm_is_image.compute_instance_image.id
-  storage_instance_image_id = var.storage_vsi_osimage_id != "" ? var.storage_vsi_osimage_id : data.ibm_is_image.storage_instance_image.id
+  compute_instance_image_id = var.compute_vsi_osimage_id != "" ? var.compute_vsi_osimage_id : data.ibm_is_image.compute_instance_image[0].id
+  storage_instance_image_id = var.storage_vsi_osimage_id != "" ? var.storage_vsi_osimage_id : data.ibm_is_image.storage_instance_image[0].id
 }
 
 module "generate_compute_cluster_keys" {
@@ -137,6 +137,7 @@ data "ibm_is_instance_profile" "compute_profile" {
 
 data "ibm_is_image" "compute_instance_image" {
   name = var.compute_vsi_osimage_name
+  count = var.compute_vsi_osimage_id != "" ? 0 : 1
 }
 
 module "compute_cluster_instances" {
@@ -169,6 +170,7 @@ data "ibm_is_ssh_key" "storage_ssh_key" {
 
 data "ibm_is_image" "storage_instance_image" {
   name = var.storage_vsi_osimage_name
+  count = var.storage_vsi_osimage_id != "" ? 0:1
 }
 
 module "storage_cluster_instances" {
@@ -198,7 +200,7 @@ module "storage_cluster_tie_breaker_instance" {
   vpc_id               = var.vpc_id
   resource_group_id    = var.resource_group_id
   zones                = [var.vpc_availability_zones[0]]
-  vsi_image_id         = data.ibm_is_image.storage_instance_image.id
+  vsi_image_id         = local.storage_instance_image_id
   vsi_profile          = var.storage_vsi_profile
   dns_domain           = var.vpc_storage_cluster_dns_domain
   dns_service_id       = var.vpc_storage_cluster_dns_service_id

--- a/ibmcloud_scale_templates/sub_modules/instance_template/variables.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/variables.tf
@@ -242,3 +242,15 @@ variable "create_scale_cluster" {
   default     = false
   description = "Flag to represent whether to create scale cluster or not."
 }
+
+variable "compute_vsi_osimage_id" {
+  type = string
+  default = ""
+  description = "Image id to use for provisioning the compute cluster instances."
+}
+
+variable "storage_vsi_osimage_id" {
+  type = string
+  default = ""
+  description = "Image id to use for provisioning the storage cluster instances."
+}


### PR DESCRIPTION
Creating this PR to get the content reviewed and merged for one of the bug we have for scale tile work
[1115](https://zenhub.ibm.com/workspaces/hpccluster-5fca9ac6798f26158474cd14/issues/workload-eng-services/hpccluster/1115)

Description:

For the Specturm scale tile work, we are creating the below mentioned three images and that needs to be made public so that can be accessed by the end users. Ideally these images are created on our internal Perf accounts and we have created the images and for the same to work we have creating a mapping file.

Where we would have the image id mentioned for each region. So when a end user provides the image name on the input parameter through schematics the code should be able to fetch the image id and associate that to the specific VSI.

With respect to that we are trying to make changes here on this code because, we want to fetch the image id for compute and storage nodes as this repo would be baked on the custom image for controller node.

Changes done:

- we are just creating a variable named image id and using the same variable as locals. As we have passed the same variable ID for the input file creation for controller node i.e (terraform.tfvars.json)
- upon fetching the image, we are validating the same at the locals added and passing the same locals details as the image id for compute and storage.

Changes added at terraform code for schematics:
https://github.ibm.com/IBMSpectrumScale/ibm-spectrum-scale-ibm-cloud-schematics/blob/image_map/main.tf#L56-L78