### PR TITLE
Update inventory file to support passwordless ssh from schematics

### DIFF
--- a/resources/common/scripts/prepare_scale_inv_ini.py
+++ b/resources/common/scripts/prepare_scale_inv_ini.py
@@ -93,7 +93,7 @@ def prepare_ansible_playbook(hosts_config, cluster_config, cluster_key_file):
   connection: local
   tasks:
   - name: Check passwordless SSH on all scale inventory hosts
-    shell: ssh -i {cluster_key_file} {{{{ inventory_hostname }}}} "echo PASSWDLESS_SSH_ENABLED"
+    shell: ssh {{{{ ansible_ssh_common_args }}}} -i {cluster_key_file} root@{{{{ inventory_hostname }}}} "echo PASSWDLESS_SSH_ENABLED"
     register: result
     until: result.stdout.find("PASSWDLESS_SSH_ENABLED") != -1
     retries: 60
@@ -736,6 +736,7 @@ if __name__ == "__main__":
     node_template = ""
     for each_entry in node_details:
         if ARGUMENTS.bastion_ssh_private_key is None:
+            each_entry = each_entry + " " + "ansible_ssh_common_args="""
             node_template = node_template + each_entry + "\n"
         else:
             proxy_command = f"ssh -p 22 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -W %h:%p {ARGUMENTS.bastion_user}@{ARGUMENTS.bastion_ip} -i {ARGUMENTS.bastion_ssh_private_key}"


### PR DESCRIPTION
Added the changes on the inventory file to create the custom ansible playbooks to support passwordless ssh to be performed from the schematics.

Now we, if we are using the bastion host for the ansible playbook creation the code fetches the ssh argument and if the playbook doesn't use the bastion node, then the ssh argument would be set as empty and no values would be considered.

The changes made has been validated on the existing scale solution and is working as expected !