### PR TITLE
[AWS] Introduce airgap variable

### DIFF
--- a/aws_scale_templates/sub_modules/instance_template/README.md
+++ b/aws_scale_templates/sub_modules/instance_template/README.md
@@ -233,6 +233,7 @@ The following steps will provision AWS resources (compute and storage instances 
 | Name | Description | Type |
 |------|-------------|------|
 | <a name="input_vpc_region"></a> [vpc_region](#input_vpc_region) | The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc. | `string` |
+| <a name="input_airgap"></a> [airgap](#input_airgap) | If true, instance iam profile, git utils which need internet access will be skipped. | `bool` |
 | <a name="input_bastion_instance_id"></a> [bastion_instance_id](#input_bastion_instance_id) | Bastion instance id. | `string` |
 | <a name="input_bastion_instance_public_ip"></a> [bastion_instance_public_ip](#input_bastion_instance_public_ip) | Bastion instance public ip address. | `string` |
 | <a name="input_bastion_security_group_id"></a> [bastion_security_group_id](#input_bastion_security_group_id) | Bastion security group id. | `string` |
@@ -290,11 +291,13 @@ The following steps will provision AWS resources (compute and storage instances 
 
 | Name | Description |
 |------|-------------|
+| <a name="output_airgap"></a> [airgap](#output_airgap) | Air gap environment |
 | <a name="output_bastion_user"></a> [bastion_user](#output_bastion_user) | Bastion OS Login username. |
 | <a name="output_compute_cluster_instance_ids"></a> [compute_cluster_instance_ids](#output_compute_cluster_instance_ids) | Compute cluster instance ids. |
 | <a name="output_compute_cluster_instance_private_ips"></a> [compute_cluster_instance_private_ips](#output_compute_cluster_instance_private_ips) | Private IP address of compute cluster instances. |
 | <a name="output_compute_cluster_security_group_id"></a> [compute_cluster_security_group_id](#output_compute_cluster_security_group_id) | Compute cluster security group id. |
 | <a name="output_compute_instance_memory_size"></a> [compute_instance_memory_size](#output_compute_instance_memory_size) | Compute instance profile memory size. |
+| <a name="output_instance_iam_profile"></a> [instance_iam_profile](#output_instance_iam_profile) | n/a |
 | <a name="output_placement_group_id"></a> [placement_group_id](#output_placement_group_id) | Placement group id. |
 | <a name="output_storage_cluster_desc_data_volume_mapping"></a> [storage_cluster_desc_data_volume_mapping](#output_storage_cluster_desc_data_volume_mapping) | Mapping of storage cluster desc instance ip vs. device path. |
 | <a name="output_storage_cluster_desc_instance_ids"></a> [storage_cluster_desc_instance_ids](#output_storage_cluster_desc_instance_ids) | Storage cluster desc instance id. |

--- a/aws_scale_templates/sub_modules/instance_template/main.tf
+++ b/aws_scale_templates/sub_modules/instance_template/main.tf
@@ -412,6 +412,7 @@ module "storage_cluster_tie_breaker_instance" {
 
 module "prepare_ansible_configuration" {
   source     = "../../../resources/common/git_utils"
+  turn_on    = (var.airgap == true) ? false : true # Disable git module in airgap mode.
   branch     = "scale_cloud"
   tag        = null
   clone_path = var.scale_ansible_repo_clone_path

--- a/aws_scale_templates/sub_modules/instance_template/main.tf
+++ b/aws_scale_templates/sub_modules/instance_template/main.tf
@@ -32,6 +32,7 @@ module "generate_storage_cluster_keys" {
 
 module "cluster_host_iam_role" {
   source           = "../../../resources/aws/security/iam/iam_role"
+  turn_on          = (var.airgap == true) ? false : true # Disable IAM role creation in airgap mode.
   role_name_prefix = format("%s-cluster-", var.resource_prefix)
   role_policy      = <<EOF
 {
@@ -52,6 +53,7 @@ EOF
 
 module "cluster_host_iam_policy" {
   source                  = "../../../resources/aws/security/iam/iam_role_policy"
+  turn_on                 = (var.airgap == true) ? false : true
   role_policy_name_prefix = format("%s-cluster-", var.resource_prefix)
   iam_role_id             = module.cluster_host_iam_role.iam_role_id
   iam_role_policy         = <<EOF
@@ -90,6 +92,7 @@ EOF
 
 module "cluster_instance_iam_profile" {
   source                       = "../../../resources/aws/security/iam/iam_instance_profile"
+  turn_on                      = (var.airgap == true) ? false : true
   instance_profile_name_prefix = format("%s-cluster-", var.resource_prefix)
   iam_host_role                = module.cluster_host_iam_policy.role_policy_name
 }
@@ -327,7 +330,7 @@ module "compute_cluster_instances" {
   ami_id                 = var.compute_cluster_image_ref
   instance_type          = var.compute_cluster_instance_type
   security_groups        = [module.compute_cluster_security_group.sec_group_id]
-  iam_instance_profile   = module.cluster_instance_iam_profile.iam_instance_profile_name
+  iam_instance_profile   = (var.airgap == true) ? null : module.cluster_instance_iam_profile.iam_instance_profile_name[0]
   placement_group        = null
   subnet_ids             = var.vpc_compute_cluster_private_subnets != null ? var.vpc_compute_cluster_private_subnets : var.vpc_storage_cluster_private_subnets
   root_volume_type       = var.compute_cluster_root_volume_type
@@ -352,7 +355,7 @@ module "storage_cluster_instances" {
   ami_id                                 = var.storage_cluster_image_ref
   instance_type                          = var.storage_cluster_instance_type
   security_groups                        = [module.storage_cluster_security_group.sec_group_id]
-  iam_instance_profile                   = module.cluster_instance_iam_profile.iam_instance_profile_name
+  iam_instance_profile                   = (var.airgap == true) ? null : module.cluster_instance_iam_profile.iam_instance_profile_name[0]
   placement_group                        = local.create_placement_group == true ? aws_placement_group.itself[0].id : null
   subnet_ids                             = var.vpc_storage_cluster_private_subnets != null ? (length(var.vpc_storage_cluster_private_subnets) > 1 ? slice(var.vpc_storage_cluster_private_subnets, 0, 2) : var.vpc_storage_cluster_private_subnets) : null
   root_volume_type                       = var.storage_cluster_root_volume_type
@@ -383,7 +386,7 @@ module "storage_cluster_tie_breaker_instance" {
   ami_id                                 = var.storage_cluster_image_ref
   instance_type                          = var.storage_cluster_tiebreaker_instance_type
   security_groups                        = [module.storage_cluster_security_group.sec_group_id]
-  iam_instance_profile                   = module.cluster_instance_iam_profile.iam_instance_profile_name
+  iam_instance_profile                   = (var.airgap == true) ? null : module.cluster_instance_iam_profile.iam_instance_profile_name[0]
   placement_group                        = null
   subnet_ids                             = var.vpc_storage_cluster_private_subnets != null ? (length(var.vpc_storage_cluster_private_subnets) > 1 ? [var.vpc_storage_cluster_private_subnets[2]] : var.vpc_storage_cluster_private_subnets) : null
   root_volume_type                       = var.storage_cluster_root_volume_type

--- a/aws_scale_templates/sub_modules/instance_template/outputs.tf
+++ b/aws_scale_templates/sub_modules/instance_template/outputs.tf
@@ -1,3 +1,8 @@
+output "airgap" {
+  value       = var.airgap
+  description = "Air gap environment"
+}
+
 output "bastion_user" {
   value       = var.bastion_user
   description = "Bastion OS Login username."
@@ -6,6 +11,10 @@ output "bastion_user" {
 output "placement_group_id" {
   value       = local.create_placement_group == true ? aws_placement_group.itself[0].id : null
   description = "Placement group id."
+}
+
+output "instance_iam_profile" {
+  value = (var.airgap == true) ? null : module.cluster_instance_iam_profile.iam_instance_profile_name[0]
 }
 
 output "compute_cluster_instance_ids" {

--- a/aws_scale_templates/sub_modules/instance_template/variables.tf
+++ b/aws_scale_templates/sub_modules/instance_template/variables.tf
@@ -1,3 +1,10 @@
+variable "airgap" {
+  type        = bool
+  nullable    = true
+  default     = null
+  description = "If true, instance iam profile, git utils which need internet access will be skipped."
+}
+
 variable "vpc_region" {
   type        = string
   description = "The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc."

--- a/resources/aws/compute/ec2_0_vol/ec2_0_vol.tf
+++ b/resources/aws/compute/ec2_0_vol/ec2_0_vol.tf
@@ -58,7 +58,7 @@ resource "aws_instance" "itself" {
   key_name             = var.user_public_key
   security_groups      = var.security_groups
   subnet_id            = each.value.subnet_id
-  iam_instance_profile = var.iam_instance_profile
+  iam_instance_profile = var.iam_instance_profile != null ? var.iam_instance_profile : null
   placement_group      = var.placement_group
 
   root_block_device {

--- a/resources/aws/compute/ec2_0_vol/ec2_0_vol.tf
+++ b/resources/aws/compute/ec2_0_vol/ec2_0_vol.tf
@@ -53,13 +53,17 @@ resource "aws_instance" "itself" {
     }
   }
 
-  ami                  = var.ami_id
-  instance_type        = var.instance_type
-  key_name             = var.user_public_key
-  security_groups      = var.security_groups
-  subnet_id            = each.value.subnet_id
-  iam_instance_profile = var.iam_instance_profile != null ? var.iam_instance_profile : null
-  placement_group      = var.placement_group
+  ami             = var.ami_id
+  instance_type   = var.instance_type
+  key_name        = var.user_public_key
+  security_groups = var.security_groups
+  subnet_id       = each.value.subnet_id
+
+  # Only include iam_instance_profile if var.iam_instance_profile is a non-empty string
+  # otherwise, skip the parameter entirely
+  iam_instance_profile = var.iam_instance_profile != "" ? var.iam_instance_profile : null
+
+  placement_group = var.placement_group
 
   root_block_device {
     encrypted             = var.root_volume_encrypted == false ? null : true

--- a/resources/aws/compute/ec2_multiple_vol/ec2_multiple_vol.tf
+++ b/resources/aws/compute/ec2_multiple_vol/ec2_multiple_vol.tf
@@ -98,14 +98,18 @@ resource "aws_instance" "itself" {
     }
   }
 
-  ami                  = var.ami_id
-  instance_type        = var.instance_type
-  key_name             = var.user_public_key
-  security_groups      = var.security_groups
-  subnet_id            = each.value.subnet_id
-  iam_instance_profile = var.iam_instance_profile
-  placement_group      = var.placement_group
-  ebs_optimized        = tobool(var.ebs_optimized)
+  ami             = var.ami_id
+  instance_type   = var.instance_type
+  key_name        = var.user_public_key
+  security_groups = var.security_groups
+  subnet_id       = each.value.subnet_id
+
+  # Only include iam_instance_profile if var.iam_instance_profile is a non-empty string
+  # otherwise, skip the parameter entirely
+  iam_instance_profile = var.iam_instance_profile != "" ? var.iam_instance_profile : null
+
+  placement_group = var.placement_group
+  ebs_optimized   = tobool(var.ebs_optimized)
 
   root_block_device {
     encrypted             = var.ebs_block_device_encrypted == false ? null : true

--- a/resources/aws/security/iam/iam_instance_profile/iam_instance_profile.tf
+++ b/resources/aws/security/iam/iam_instance_profile/iam_instance_profile.tf
@@ -4,13 +4,15 @@
 
 variable "instance_profile_name_prefix" {}
 variable "iam_host_role" {}
+variable "turn_on" {}
 
 resource "aws_iam_instance_profile" "itself" {
+  count       = (var.turn_on == true) ? 1 : 0
   name_prefix = var.instance_profile_name_prefix
-  role        = var.iam_host_role
+  role        = element(var.iam_host_role, count.index)
   path        = "/"
 }
 
 output "iam_instance_profile_name" {
-  value = aws_iam_instance_profile.itself.name
+  value = aws_iam_instance_profile.itself[*].name
 }

--- a/resources/aws/security/iam/iam_role/iam_role.tf
+++ b/resources/aws/security/iam/iam_role/iam_role.tf
@@ -4,17 +4,19 @@
 
 variable "role_name_prefix" {}
 variable "role_policy" {}
+variable "turn_on" {}
 
 resource "aws_iam_role" "itself" {
+  count              = (var.turn_on == true) ? 1 : 0
   name_prefix        = var.role_name_prefix
   path               = "/"
   assume_role_policy = var.role_policy
 }
 
 output "iam_role_id" {
-  value = aws_iam_role.itself.id
+  value = aws_iam_role.itself[*].id
 }
 
 output "iam_role_arn" {
-  value = aws_iam_role.itself.arn
+  value = aws_iam_role.itself[*].arn
 }

--- a/resources/aws/security/iam/iam_role_policy/iam_role_policy.tf
+++ b/resources/aws/security/iam/iam_role_policy/iam_role_policy.tf
@@ -5,21 +5,23 @@
 variable "role_policy_name_prefix" {}
 variable "iam_role_id" {}
 variable "iam_role_policy" {}
+variable "turn_on" {}
 
 resource "aws_iam_role_policy" "itself" {
+  count       = (var.turn_on == true) ? 1 : 0
   name_prefix = var.role_policy_name_prefix
-  role        = var.iam_role_id
+  role        = element(var.iam_role_id, count.index)
   policy      = var.iam_role_policy
 }
 
 output "role_name" {
-  value = aws_iam_role_policy.itself.name
+  value = aws_iam_role_policy.itself[*].name
 }
 
 output "role_policy_name" {
-  value = aws_iam_role_policy.itself.role
+  value = aws_iam_role_policy.itself[*].role
 }
 
 output "role_policy_id" {
-  value = aws_iam_role_policy.itself.id
+  value = aws_iam_role_policy.itself[*].id
 }

--- a/resources/common/git_utils/git_utils.tf
+++ b/resources/common/git_utils/git_utils.tf
@@ -5,21 +5,24 @@
 variable "branch" {}
 variable "tag" {}
 variable "clone_path" {}
+variable "turn_on" {}
 
 terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~>4.9.2"
+      version = "~>5.0"
     }
   }
 }
 
 data "github_repository" "ansible_repo" {
+  count     = (var.turn_on == true) ? 1 : 0
   full_name = "IBM/ibm-spectrum-scale-install-infra"
 }
 
 resource "null_resource" "create_clone_path" {
+  count = (var.turn_on == true) ? 1 : 0
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     command     = "mkdir -p ${var.clone_path}"
@@ -27,19 +30,19 @@ resource "null_resource" "create_clone_path" {
 }
 
 resource "null_resource" "clone_repo_branch" {
-  count = var.tag == null ? 1 : 0
+  count = (var.tag == null && var.turn_on == true) ? 1 : 0
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = "if [ -z \"$(ls -A ${var.clone_path})\" ]; then git -C ${var.clone_path} clone -b ${var.branch} ${data.github_repository.ansible_repo.http_clone_url}; fi"
+    command     = "if [ -z \"$(ls -A ${var.clone_path})\" ]; then git -C ${var.clone_path} clone -b ${var.branch} ${data.github_repository.ansible_repo[0].http_clone_url}; fi"
   }
   depends_on = [null_resource.create_clone_path]
 }
 
 resource "null_resource" "clone_repo_tag" {
-  count = var.tag != null ? 1 : 0
+  count = (var.tag != null && var.turn_on == true) ? 1 : 0
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = "if [ -z \"$(ls -A ${var.clone_path})\" ]; then git -C ${var.clone_path} clone --branch ${var.tag} ${data.github_repository.ansible_repo.http_clone_url}; fi"
+    command     = "if [ -z \"$(ls -A ${var.clone_path})\" ]; then git -C ${var.clone_path} clone --branch ${var.tag} ${data.github_repository.ansible_repo[0].http_clone_url}; fi"
   }
   depends_on = [null_resource.create_clone_path]
 }


### PR DESCRIPTION
In aws airgap mode, it skips the IAM instance role creation and attachment to instance (required due to lack of IAM endpoint or iam:PassRole)