### PR TITLE
Adding support for 'data google_compute_subnetwork' block  to work seamless  on 'self_link' as well 'name' inputs

### DIFF
--- a/gcp_scale_templates/sub_modules/bastion_template/main.tf
+++ b/gcp_scale_templates/sub_modules/bastion_template/main.tf
@@ -31,7 +31,7 @@ module "allow_traffic_from_external_cidr_to_bastion" {
 
 data "google_compute_subnetwork" "public_bastion_cluster" {
   count     = var.vpc_auto_scaling_group_subnets != null ? 1 : 0
-  self_link = length(regexall("^https", var.vpc_auto_scaling_group_subnets[0])) > 0 ? var.vpc_auto_scaling_group_subnets[0] : "https://www.googleapis.com/compute/v1/projects/${var.project_id}/regions/us-central1/subnetworks/${var.vpc_auto_scaling_group_subnets[0]}"
+  self_link = length(regexall("^https", var.vpc_auto_scaling_group_subnets[0])) > 0 ? var.vpc_auto_scaling_group_subnets[0] : "https://www.googleapis.com/compute/v1/projects/${var.project_id}/regions/${var.vpc_region}/subnetworks/${var.vpc_auto_scaling_group_subnets[0]}"
 }
 
 # Allow traffic bastion internals

--- a/gcp_scale_templates/sub_modules/bastion_template/main.tf
+++ b/gcp_scale_templates/sub_modules/bastion_template/main.tf
@@ -30,8 +30,8 @@ module "allow_traffic_from_external_cidr_to_bastion" {
 }
 
 data "google_compute_subnetwork" "public_bastion_cluster" {
-  count     = var.vpc_auto_scaling_group_subnets != null ? 1 : 0
-  self_link = var.vpc_auto_scaling_group_subnets[0]
+  count = var.vpc_auto_scaling_group_subnets != null ? 1 : 0
+  name  = var.vpc_auto_scaling_group_subnets[0]
 }
 
 # Allow traffic bastion internals

--- a/gcp_scale_templates/sub_modules/bastion_template/main.tf
+++ b/gcp_scale_templates/sub_modules/bastion_template/main.tf
@@ -30,8 +30,8 @@ module "allow_traffic_from_external_cidr_to_bastion" {
 }
 
 data "google_compute_subnetwork" "public_bastion_cluster" {
-  count = var.vpc_auto_scaling_group_subnets != null ? 1 : 0
-  name  = var.vpc_auto_scaling_group_subnets[0]
+  count     = var.vpc_auto_scaling_group_subnets != null ? 1 : 0
+  self_link = length(regexall("^https", var.vpc_auto_scaling_group_subnets[0])) > 0 ? var.vpc_auto_scaling_group_subnets[0] : "https://www.googleapis.com/compute/v1/projects/${var.project_id}/regions/us-central1/subnetworks/${var.vpc_auto_scaling_group_subnets[0]}"
 }
 
 # Allow traffic bastion internals

--- a/gcp_scale_templates/sub_modules/bastion_template/outputs.tf
+++ b/gcp_scale_templates/sub_modules/bastion_template/outputs.tf
@@ -9,7 +9,7 @@ output "bastion_instance_name" {
 }
 
 output "bastion_instance_ref" {
-  value       = data.google_compute_instance.itself[*].id
+  value       = data.google_compute_instance.itself[*].self_link
   description = "Bastion instance Ids."
 }
 

--- a/gcp_scale_templates/sub_modules/instance_template/main.tf
+++ b/gcp_scale_templates/sub_modules/instance_template/main.tf
@@ -104,12 +104,12 @@ module "generate_storage_cluster_keys" {
 
 data "google_compute_subnetwork" "storage_cluster" {
   count     = var.vpc_storage_cluster_private_subnets != null ? length(var.vpc_storage_cluster_private_subnets) > 0 ? length(var.vpc_storage_cluster_private_subnets) : 0 : 0
-  self_link = length(regexall("^https", var.vpc_storage_cluster_private_subnets[count.index])) > 0 ? var.vpc_storage_cluster_private_subnets[count.index] : "https://www.googleapis.com/compute/v1/projects/${var.project_id}/regions/us-central1/subnetworks/${var.vpc_storage_cluster_private_subnets[count.index]}"
+  self_link = length(regexall("^https", var.vpc_storage_cluster_private_subnets[count.index])) > 0 ? var.vpc_storage_cluster_private_subnets[count.index] : "https://www.googleapis.com/compute/v1/projects/${var.project_id}/regions/${var.vpc_region}/subnetworks/${var.vpc_storage_cluster_private_subnets[count.index]}"
 }
 
 data "google_compute_subnetwork" "compute_cluster" {
   count     = var.vpc_compute_cluster_private_subnets != null ? length(var.vpc_compute_cluster_private_subnets) > 0 ? length(var.vpc_compute_cluster_private_subnets) : 0 : 0
-  self_link = length(regexall("^https", var.vpc_compute_cluster_private_subnets[count.index])) > 0 ? var.vpc_compute_cluster_private_subnets[count.index] : "https://www.googleapis.com/compute/v1/projects/${var.project_id}/regions/us-central1/subnetworks/${var.vpc_compute_cluster_private_subnets[count.index]}"
+  self_link = length(regexall("^https", var.vpc_compute_cluster_private_subnets[count.index])) > 0 ? var.vpc_compute_cluster_private_subnets[count.index] : "https://www.googleapis.com/compute/v1/projects/${var.project_id}/regions/${var.vpc_region}/subnetworks/${var.vpc_compute_cluster_private_subnets[count.index]}"
 }
 
 data "google_compute_instance" "google_compute_instance" {

--- a/gcp_scale_templates/sub_modules/instance_template/main.tf
+++ b/gcp_scale_templates/sub_modules/instance_template/main.tf
@@ -103,13 +103,13 @@ module "generate_storage_cluster_keys" {
 }
 
 data "google_compute_subnetwork" "storage_cluster" {
-  count     = var.vpc_storage_cluster_private_subnets != null ? length(var.vpc_storage_cluster_private_subnets) > 0 ? length(var.vpc_storage_cluster_private_subnets) : 0 : 0
-  self_link = var.vpc_storage_cluster_private_subnets[count.index]
+  count = var.vpc_storage_cluster_private_subnets != null ? length(var.vpc_storage_cluster_private_subnets) > 0 ? length(var.vpc_storage_cluster_private_subnets) : 0 : 0
+  name  = var.vpc_storage_cluster_private_subnets[count.index]
 }
 
 data "google_compute_subnetwork" "compute_cluster" {
-  count     = var.vpc_compute_cluster_private_subnets != null ? length(var.vpc_compute_cluster_private_subnets) > 0 ? length(var.vpc_compute_cluster_private_subnets) : 0 : 0
-  self_link = var.vpc_compute_cluster_private_subnets[count.index]
+  count = var.vpc_compute_cluster_private_subnets != null ? length(var.vpc_compute_cluster_private_subnets) > 0 ? length(var.vpc_compute_cluster_private_subnets) : 0 : 0
+  name  = var.vpc_compute_cluster_private_subnets[count.index]
 }
 
 data "google_compute_instance" "google_compute_instance" {

--- a/gcp_scale_templates/sub_modules/instance_template/main.tf
+++ b/gcp_scale_templates/sub_modules/instance_template/main.tf
@@ -236,8 +236,8 @@ module "compute_cluster_instances" {
   instance_name           = format("%s-compute", var.resource_prefix)
   machine_type            = var.compute_cluster_instance_type
   vpc_subnets             = var.vpc_compute_cluster_private_subnets != null ? var.vpc_compute_cluster_private_subnets : null
-  private_key_content     = module.generate_compute_cluster_keys.private_key_content
-  public_key_content      = module.generate_compute_cluster_keys.public_key_content
+  private_key_content     = var.create_remote_mount_cluster == true ? module.generate_compute_cluster_keys.private_key_content : module.generate_storage_cluster_keys.private_key_content
+  public_key_content      = var.create_remote_mount_cluster == true ? module.generate_compute_cluster_keys.public_key_content : module.generate_storage_cluster_keys.public_key_content
   service_email           = var.service_email
   scopes                  = var.scopes
   boot_disk_size          = var.compute_boot_disk_size
@@ -355,7 +355,7 @@ module "write_storage_cluster_inventory" {
   storage_cluster_with_data_volume_mapping         = length(module.storage_cluster_instances) > 0 ? jsonencode((module.storage_cluster_instances[*].disk_device_mapping)[0]) : jsonencode({})
   storage_cluster_instance_private_dns_ip_map      = length(module.storage_cluster_instances) > 0 ? jsonencode((module.storage_cluster_instances[*].dns_hostname)[0]) : jsonencode({})
   storage_cluster_desc_instance_ids                = jsonencode(flatten(module.storage_cluster_tie_breaker_instance[*].instance_selflink))
-  storage_cluster_desc_instance_private_ips        = jsonencode(module.storage_cluster_tie_breaker_instance[*].instance_ips)
+  storage_cluster_desc_instance_private_ips        = jsonencode(flatten(module.storage_cluster_tie_breaker_instance[*].instance_ips))
   storage_cluster_desc_data_volume_mapping         = length(module.storage_cluster_tie_breaker_instance) > 0 ? jsonencode((flatten(module.storage_cluster_tie_breaker_instance[*].disk_device_mapping))[0]) : jsonencode({})
   storage_cluster_desc_instance_private_dns_ip_map = length(module.storage_cluster_tie_breaker_instance) > 0 ? jsonencode((flatten(module.storage_cluster_tie_breaker_instance[*].dns_hostname))[0]) : jsonencode({})
 }
@@ -385,7 +385,7 @@ module "write_cluster_inventory" {
   storage_cluster_with_data_volume_mapping         = length(module.storage_cluster_instances) > 0 ? jsonencode((module.storage_cluster_instances[*].disk_device_mapping)[0]) : jsonencode({})
   storage_cluster_instance_private_dns_ip_map      = length(module.storage_cluster_instances) > 0 ? jsonencode((module.storage_cluster_instances[*].dns_hostname)[0]) : jsonencode({})
   storage_cluster_desc_instance_ids                = jsonencode(flatten(module.storage_cluster_tie_breaker_instance[*].instance_selflink))
-  storage_cluster_desc_instance_private_ips        = jsonencode(module.storage_cluster_tie_breaker_instance[*].instance_ips)
+  storage_cluster_desc_instance_private_ips        = jsonencode(flatten(module.storage_cluster_tie_breaker_instance[*].instance_ips))
   storage_cluster_desc_data_volume_mapping         = length(module.storage_cluster_tie_breaker_instance) > 0 ? jsonencode((flatten(module.storage_cluster_tie_breaker_instance[*].disk_device_mapping))[0]) : jsonencode({})
   storage_cluster_desc_instance_private_dns_ip_map = length(module.storage_cluster_tie_breaker_instance) > 0 ? jsonencode((flatten(module.storage_cluster_tie_breaker_instance[*].dns_hostname))[0]) : jsonencode({})
 }
@@ -440,4 +440,27 @@ module "storage_cluster_configuration" {
   scale_version                = local.scale_version
   spectrumscale_rpms_path      = var.spectrumscale_rpms_path
   depends_on                   = [module.storage_cluster_instances]
+}
+
+# Configure the combined cluster using ansible based on the create_scale_cluster input.
+module "combined_cluster_configuration" {
+  source                       = "../../../resources/common/scale_configuration"
+  turn_on                      = (var.create_remote_mount_cluster == false && local.cluster_type == "combined") ? true : false
+  clone_complete               = module.prepare_ansible_configuration.clone_complete
+  write_inventory_complete     = module.write_cluster_inventory.write_inventory_complete
+  inventory_format             = var.inventory_format
+  create_scale_cluster         = var.create_scale_cluster
+  clone_path                   = var.scale_ansible_repo_clone_path
+  inventory_path               = format("%s/cluster_inventory.json", var.scale_ansible_repo_clone_path)
+  using_packer_image           = var.using_packer_image
+  using_jumphost_connection    = var.using_jumphost_connection
+  storage_cluster_gui_username = var.storage_cluster_gui_username
+  storage_cluster_gui_password = var.storage_cluster_gui_password
+  memory_size                  = 4
+  bastion_user                 = var.bastion_user == null ? jsonencode("None") : jsonencode(var.bastion_user)
+  bastion_instance_public_ip   = var.bastion_instance_public_ip == null ? jsonencode("None") : jsonencode(var.bastion_instance_public_ip)
+  bastion_ssh_private_key      = var.bastion_ssh_private_key == null ? jsonencode("None") : jsonencode(var.bastion_ssh_private_key)
+  meta_private_key             = module.generate_storage_cluster_keys.private_key_content
+  scale_version                = local.scale_version
+  spectrumscale_rpms_path      = var.spectrumscale_rpms_path
 }

--- a/gcp_scale_templates/sub_modules/instance_template/main.tf
+++ b/gcp_scale_templates/sub_modules/instance_template/main.tf
@@ -103,13 +103,13 @@ module "generate_storage_cluster_keys" {
 }
 
 data "google_compute_subnetwork" "storage_cluster" {
-  count = var.vpc_storage_cluster_private_subnets != null ? length(var.vpc_storage_cluster_private_subnets) > 0 ? length(var.vpc_storage_cluster_private_subnets) : 0 : 0
-  name  = var.vpc_storage_cluster_private_subnets[count.index]
+  count     = var.vpc_storage_cluster_private_subnets != null ? length(var.vpc_storage_cluster_private_subnets) > 0 ? length(var.vpc_storage_cluster_private_subnets) : 0 : 0
+  self_link = length(regexall("^https", var.vpc_storage_cluster_private_subnets[count.index])) > 0 ? var.vpc_storage_cluster_private_subnets[count.index] : "https://www.googleapis.com/compute/v1/projects/${var.project_id}/regions/us-central1/subnetworks/${var.vpc_storage_cluster_private_subnets[count.index]}"
 }
 
 data "google_compute_subnetwork" "compute_cluster" {
-  count = var.vpc_compute_cluster_private_subnets != null ? length(var.vpc_compute_cluster_private_subnets) > 0 ? length(var.vpc_compute_cluster_private_subnets) : 0 : 0
-  name  = var.vpc_compute_cluster_private_subnets[count.index]
+  count     = var.vpc_compute_cluster_private_subnets != null ? length(var.vpc_compute_cluster_private_subnets) > 0 ? length(var.vpc_compute_cluster_private_subnets) : 0 : 0
+  self_link = length(regexall("^https", var.vpc_compute_cluster_private_subnets[count.index])) > 0 ? var.vpc_compute_cluster_private_subnets[count.index] : "https://www.googleapis.com/compute/v1/projects/${var.project_id}/regions/us-central1/subnetworks/${var.vpc_compute_cluster_private_subnets[count.index]}"
 }
 
 data "google_compute_instance" "google_compute_instance" {

--- a/gcp_scale_templates/sub_modules/vpc_template/outputs.tf
+++ b/gcp_scale_templates/sub_modules/vpc_template/outputs.tf
@@ -9,17 +9,17 @@ output "cluster_type" {
 }
 
 output "vpc_public_subnets" {
-  value       = module.public_subnet.subnet_uri
+  value       = module.public_subnet.subnet_name
   description = "List of IDs of public subnets."
 }
 
 output "vpc_storage_cluster_private_subnets" {
-  value       = (local.cluster_type == "storage" || local.cluster_type == "combined") ? module.storage_private_subnet.subnet_uri : null
+  value       = (local.cluster_type == "storage" || local.cluster_type == "combined") ? module.storage_private_subnet.subnet_name : null
   description = "List of IDs of storage cluster private subnets."
 }
 
 output "vpc_compute_cluster_private_subnets" {
-  value       = (local.cluster_type == "compute" || local.cluster_type == "combined") ? module.compute_private_subnet.subnet_uri : null
+  value       = (local.cluster_type == "compute" || local.cluster_type == "combined") ? module.compute_private_subnet.subnet_name : null
   description = "List of IDs of compute cluster private subnets."
 }
 

--- a/gcp_scale_templates/sub_modules/vpc_template/outputs.tf
+++ b/gcp_scale_templates/sub_modules/vpc_template/outputs.tf
@@ -9,17 +9,17 @@ output "cluster_type" {
 }
 
 output "vpc_public_subnets" {
-  value       = module.public_subnet.subnet_name
+  value       = module.public_subnet.subnet_uri
   description = "List of IDs of public subnets."
 }
 
 output "vpc_storage_cluster_private_subnets" {
-  value       = (local.cluster_type == "storage" || local.cluster_type == "combined") ? module.storage_private_subnet.subnet_name : null
+  value       = (local.cluster_type == "storage" || local.cluster_type == "combined") ? module.storage_private_subnet.subnet_uri : null
   description = "List of IDs of storage cluster private subnets."
 }
 
 output "vpc_compute_cluster_private_subnets" {
-  value       = (local.cluster_type == "compute" || local.cluster_type == "combined") ? module.compute_private_subnet.subnet_name : null
+  value       = (local.cluster_type == "compute" || local.cluster_type == "combined") ? module.compute_private_subnet.subnet_uri : null
   description = "List of IDs of compute cluster private subnets."
 }
 

--- a/resources/gcp/network/subnet/subnet.tf
+++ b/resources/gcp/network/subnet/subnet.tf
@@ -39,7 +39,7 @@ resource "google_compute_subnetwork" "itself" {
 
 
 output "subnet_name" {
-  value      = format("%s-subnet", var.subnet_name_prefix)
+  value      = google_compute_subnetwork.itself[*].name
   depends_on = [google_compute_subnetwork.itself]
 }
 


### PR DESCRIPTION
Adding support for google_compute_subnetwork to work on self_link as well subnet name

- 'data google_compute_subnetwork' will works only for name or self_link . 
-  since we have chosen self_link in all our code , data access using name would result in error state.

Hence , this code makes our data access to google_compute_subnetwork to work seamless for both 'name' as well 'self_link'