### PR TITLE
[IBM Cloud] Scale Tile Refresh for Scale-5.1.8.1-Reg

### DIFF
--- a/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
@@ -8,7 +8,8 @@
 
 locals {
   gpfs_base_rpm_path = fileset(var.spectrumscale_rpms_path, "gpfs.base-*")
-  scale_version      = regex("gpfs.base-(.*).x86_64.rpm", tolist(local.gpfs_base_rpm_path)[0])[0]
+  scale_org_version  = regex("gpfs.base-(.*).x86_64.rpm", tolist(local.gpfs_base_rpm_path)[0])[0]
+  scale_version      = replace(local.scale_org_version, "-", ".")
 }
 
 locals {

--- a/resources/common/scripts/prepare_remote_mount_inv.py
+++ b/resources/common/scripts/prepare_remote_mount_inv.py
@@ -65,6 +65,8 @@ def prepare_remote_mount_playbook(hosts_config, mount_details):
     content = """---
 # Config remote mount
 - hosts: {hosts_config}
+  collections:
+     - ibm.spectrum_scale
   vars:
     - scale_remotemount_client_gui_username: {compute_gui_username}
     - scale_remotemount_client_gui_password: {compute_gui_password}

--- a/resources/common/scripts/prepare_scale_inv_ini.py
+++ b/resources/common/scripts/prepare_scale_inv_ini.py
@@ -131,6 +131,8 @@ def prepare_ansible_playbook(hosts_config, cluster_config, cluster_key_file):
 
 # Install and config Spectrum Scale on nodes
 - hosts: {hosts_config}
+  collections:
+     - ibm.spectrum_scale
   any_errors_fatal: true
   pre_tasks:
      - include_vars: group_vars/{cluster_config}
@@ -138,7 +140,7 @@ def prepare_ansible_playbook(hosts_config, cluster_config, cluster_key_file):
      - core_prepare
      - {{ role: core_install, when: "scale_packages_installed is false" }}
      - core_configure
-     - gui_prepare
+#    - gui_prepare
      - {{ role: gui_install, when: "scale_packages_installed is false" }}
      - gui_configure
      - gui_verify
@@ -156,6 +158,8 @@ def prepare_packer_ansible_playbook(hosts_config, cluster_config):
     content = """---
 # Install and config Spectrum Scale on nodes
 - hosts: {hosts_config}
+  collections:
+     - ibm.spectrum_scale
   any_errors_fatal: true
   pre_tasks:
      - include_vars: group_vars/{cluster_config}
@@ -174,6 +178,8 @@ def prepare_nogui_ansible_playbook(hosts_config, cluster_config):
     content = """---
 # Install and config Spectrum Scale on nodes
 - hosts: {hosts_config}
+  collections:
+     - ibm.spectrum_scale
   any_errors_fatal: true
   pre_tasks:
      - include_vars: group_vars/{cluster_config}
@@ -190,6 +196,8 @@ def prepare_nogui_packer_ansible_playbook(hosts_config, cluster_config):
     content = """---
 # Install and config Spectrum Scale on nodes
 - hosts: {hosts_config}
+  collections:
+     - ibm.spectrum_scale
   any_errors_fatal: true
   pre_tasks:
      - include_vars: group_vars/{cluster_config}

--- a/resources/ibmcloud/compute/vsi_0_vol/vsi_0_vol.tf
+++ b/resources/ibmcloud/compute/vsi_0_vol/vsi_0_vol.tf
@@ -42,7 +42,7 @@ then
         package_list="python38 kernel-devel-$(uname -r) kernel-headers-$(uname -r)"
     else
         PACKAGE_MGR=yum
-        package_list="python3 kernel-devel-$(uname -r) kernel-headers-$(uname -r)"
+        package_list="python3 kernel-devel-$(uname -r) kernel-headers-$(uname -r) rsync"
     fi
 
     RETRY_LIMIT=5


### PR DESCRIPTION
@sasikeda 

Changes as follows,

- Added collections for the new ansible-playbook structure
- Updated scale version expected output as 5.1.8.1 instead of 5.1.8-1 which requires for GPG key check.
- Installing rsync for stock os image for RHEL-7.9 which requires for copying the packages during runtime installation.
- Skipped gui-prepare task.

FYI - @digvijay-ukirde  @mamuthiah @rajan-mis 