### PR TITLE
Remove persistent storage type condition on Compute cluster

### DIFF
--- a/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
@@ -21,7 +21,7 @@ locals {
 
 # Getting bandwidth of compute and storage vsi and based on that checking mrot will be enabled or not.
 locals {
-  enable_sec_interface_compute = var.storage_type != "persistent" && data.ibm_is_instance_profile.compute_profile.bandwidth[0].value >= 64000 ? true : false
+  enable_sec_interface_compute = data.ibm_is_instance_profile.compute_profile.bandwidth[0].value >= 64000 ? true : false
   enable_sec_interface_storage = var.storage_type != "persistent" && data.ibm_is_instance_profile.storage_profile.bandwidth[0].value >= 64000 ? true : false
   enable_mrot_conf             = local.enable_sec_interface_compute && local.enable_sec_interface_storage ? true : false
 }


### PR DESCRIPTION
This PR is related compute cluster should create secondary interface even if storage type is Persistent.