### PR TITLE
Move packer image creation to private subnets, use bastion as proxy

### DIFF
--- a/packer_templates/aws/aws.pkr.hcl
+++ b/packer_templates/aws/aws.pkr.hcl
@@ -1,23 +1,31 @@
 source "amazon-ebs" "itself" {
-  vpc_id                      = var.vpc_ref
-  subnet_id                   = var.vpc_subnet_id
-  associate_public_ip_address = true
-  security_group_id           = var.vpc_security_group_id
+  vpc_id    = var.vpc_ref
+  subnet_id = var.vpc_subnet_id
   launch_block_device_mappings {
     device_name           = "/dev/sda1"
     volume_size           = var.volume_size
     volume_type           = var.volume_type
     delete_on_termination = true
   }
-  ami_description           = var.image_description
-  ami_virtualization_type   = "hvm"
-  ami_name                  = "${var.resource_prefix}-{{timestamp}}"
-  instance_type             = var.instance_type
-  region                    = var.vpc_region
-  source_ami                = var.source_image_reference
-  ssh_username              = var.ssh_username
-  ssh_clear_authorized_keys = true
-  temporary_key_pair_name   = "amazon-packer-{{timestamp}}"
+  ami_description              = var.image_description
+  ami_virtualization_type      = "hvm"
+  ami_name                     = "${var.resource_prefix}-{{timestamp}}"
+  instance_type                = var.instance_type
+  region                       = var.vpc_region
+  source_ami                   = var.source_image_reference
+  security_group_id            = var.vpc_security_group_id
+  associate_public_ip_address  = false
+  communicator                 = "ssh"
+  ssh_interface                = "private_ip"
+  ssh_username                 = var.ssh_username
+  ssh_port                     = var.ssh_port
+  ssh_bastion_host             = var.ssh_bastion_host
+  ssh_bastion_username         = var.ssh_bastion_username
+  ssh_bastion_port             = var.ssh_bastion_port
+  ssh_bastion_private_key_file = var.ssh_bastion_private_key_file
+  ssh_clear_authorized_keys    = true
+  ssh_timeout                  = 2m
+  temporary_key_pair_name      = "amazon-packer-{{timestamp}}"
 
   metadata_options {
     http_endpoint               = "enabled"

--- a/packer_templates/aws/aws.pkr.hcl
+++ b/packer_templates/aws/aws.pkr.hcl
@@ -24,7 +24,7 @@ source "amazon-ebs" "itself" {
   ssh_bastion_port             = var.ssh_bastion_port
   ssh_bastion_private_key_file = var.ssh_bastion_private_key_file
   ssh_clear_authorized_keys    = true
-  ssh_timeout                  = 2m
+  ssh_timeout                  = "2m"
   temporary_key_pair_name      = "amazon-packer-{{timestamp}}"
 
   metadata_options {

--- a/packer_templates/aws/variables.pkr.hcl
+++ b/packer_templates/aws/variables.pkr.hcl
@@ -11,6 +11,7 @@ variable "vpc_region" {
 # If the security group id is not provided, a temporary security group with ssh access will be provisioned and cleaned up
 variable "vpc_security_group_id" {
   type        = string
+  default     = null
   description = "The security group id to assign to the instance, you must be sure the security group allows access to the ssh port."
 }
 
@@ -52,7 +53,7 @@ variable "ssh_bastion_port" {
 }
 
 variable "ssh_bastion_private_key_file" {
-  tyoe        = string
+  type        = string
   description = "Path to a private key file to use to authenticate with the bastion host."
 }
 

--- a/packer_templates/aws/variables.pkr.hcl
+++ b/packer_templates/aws/variables.pkr.hcl
@@ -8,6 +8,7 @@ variable "vpc_region" {
   description = "The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc."
 }
 
+# If the security group id is not provided, a temporary security group with ssh access will be provisioned and cleaned up
 variable "vpc_security_group_id" {
   type        = string
   description = "The security group id to assign to the instance, you must be sure the security group allows access to the ssh port."
@@ -26,6 +27,33 @@ variable "resource_prefix" {
 variable "ssh_username" {
   type        = string
   description = "The username to connect to instance via SSH."
+}
+
+variable "ssh_port" {
+  type        = string
+  default     = "22"
+  description = "The port to connect to instance via SSH."
+}
+
+variable "ssh_bastion_host" {
+  type        = string
+  description = "A bastion host to use for the SSH connection."
+}
+
+variable "ssh_bastion_username" {
+  type        = string
+  description = "The username to connect to the bastion host."
+}
+
+variable "ssh_bastion_port" {
+  type        = string
+  default     = "22"
+  description = "The port of the bastion host."
+}
+
+variable "ssh_bastion_private_key_file" {
+  tyoe        = string
+  description = "Path to a private key file to use to authenticate with the bastion host."
 }
 
 variable "image_description" {


### PR DESCRIPTION
Currently, the packer is provisioning public IP for its communications, which is changing to use the private subnet. In case Bastion is available, it will be used as a proxy.