### PR TITLE
[fix_ 1115, 1096] Fix same subnet assocation failure, dns combined and autoscale count unique

### DIFF
--- a/azure_scale_templates/sub_modules/bastion_template/main.tf
+++ b/azure_scale_templates/sub_modules/bastion_template/main.tf
@@ -66,7 +66,7 @@ module "azure_bastion_service" {
 module "bastion_autoscaling_group" {
   count                   = var.vpc_auto_scaling_group_subnets != null ? length(var.vpc_auto_scaling_group_subnets) : 0
   source                  = "../../../resources/azure/asg/asg_scaleset"
-  vm_name_prefix          = "${var.resource_prefix}-bastion"
+  vm_name_prefix          = "${var.resource_prefix}-bastion-${count.index}"
   image_publisher         = var.image_publisher
   image_offer             = var.image_offer
   image_sku               = var.image_sku

--- a/azure_scale_templates/sub_modules/instance_template/main.tf
+++ b/azure_scale_templates/sub_modules/instance_template/main.tf
@@ -95,7 +95,7 @@ module "storage_private_dns_zone" {
 
 module "compute_private_dns_zone" {
   source              = "../../../resources/azure/network/private_dns_zone"
-  turn_on             = local.compute_or_combined == true ? true : false
+  turn_on             = var.cluster_type == "Compute-only" ? true : false
   dns_domain_name     = format("%s.%s", var.vpc_region, var.vpc_compute_cluster_dns_domain)
   resource_group_name = var.resource_group_ref
 }
@@ -111,7 +111,7 @@ module "link_storage_dns_zone_vpc" {
 
 module "link_compute_dns_zone_vpc" {
   source                = "../../../resources/azure/network/private_dns_zone_vpc_link"
-  turn_on               = local.compute_or_combined == true ? true : false
+  turn_on               = var.cluster_type == "Compute-only" ? true : false
   private_dns_zone_name = module.compute_private_dns_zone.private_dns_zone_name
   resource_group_name   = var.resource_group_ref
   vnet_id               = var.vpc_ref
@@ -133,7 +133,7 @@ resource "time_sleep" "wait_30_seconds" {
 }
 
 module "associate_compute_nsg_wth_subnet" {
-  count                     = var.vpc_compute_cluster_private_subnets != null && local.compute_or_combined ? length(var.vpc_compute_cluster_private_subnets) : 0
+  count                     = var.vpc_compute_cluster_private_subnets != null && local.compute_or_combined && length(setintersection(toset(coalesce(var.vpc_compute_cluster_private_subnets, ["none"])), toset(coalesce(var.vpc_storage_cluster_private_subnets, ["non"])))) == 0 ? length(var.vpc_compute_cluster_private_subnets) : 0
   source                    = "../../../resources/azure/security/network_security_group_association"
   subnet_id                 = var.vpc_compute_cluster_private_subnets[count.index]
   network_security_group_id = module.scale_cluster_nsg.sec_group_id
@@ -156,10 +156,10 @@ module "compute_cluster_instances" {
   user_key_pair                 = var.create_remote_mount_cluster == true ? var.compute_cluster_key_pair : var.storage_cluster_key_pair
   meta_private_key              = var.create_remote_mount_cluster == true ? module.generate_compute_cluster_keys.private_key_content : module.generate_storage_cluster_keys.private_key_content
   meta_public_key               = var.create_remote_mount_cluster == true ? module.generate_compute_cluster_keys.public_key_content : module.generate_storage_cluster_keys.public_key_content
-  dns_zone                      = module.compute_private_dns_zone.private_dns_zone_name
+  dns_zone                      = format("%s.%s", var.vpc_region, var.vpc_compute_cluster_dns_domain)
   availability_zone             = each.value["zone"]
   application_security_group_id = module.scale_cluster_asg.asg_id
-  depends_on                    = [module.compute_private_dns_zone]
+  depends_on                    = [module.compute_private_dns_zone, module.storage_private_dns_zone]
 }
 
 module "associate_storage_nsg_wth_subnet" {
@@ -188,7 +188,7 @@ module "storage_cluster_instances" {
   user_key_pair                  = var.storage_cluster_key_pair
   meta_private_key               = module.generate_storage_cluster_keys.private_key_content
   meta_public_key                = module.generate_storage_cluster_keys.public_key_content
-  dns_zone                       = module.storage_private_dns_zone.private_dns_zone_name
+  dns_zone                       = format("%s.%s", var.vpc_region, var.vpc_storage_cluster_dns_domain)
   availability_zone              = each.value["zone"]
   disks                          = each.value["disks"]
   application_security_group_id  = module.scale_cluster_asg.asg_id
@@ -213,7 +213,7 @@ module "storage_cluster_tie_breaker_instance" {
   user_key_pair                  = var.storage_cluster_key_pair
   meta_private_key               = module.generate_storage_cluster_keys.private_key_content
   meta_public_key                = module.generate_storage_cluster_keys.public_key_content
-  dns_zone                       = var.vpc_storage_cluster_dns_domain
+  dns_zone                       = format("%s.%s", var.vpc_region, var.vpc_storage_cluster_dns_domain)
   availability_zone              = each.value["zone"]
   disks                          = each.value["disks"]
   application_security_group_id  = module.scale_cluster_asg.asg_id

--- a/azure_scale_templates/sub_modules/instance_template/main.tf
+++ b/azure_scale_templates/sub_modules/instance_template/main.tf
@@ -133,7 +133,7 @@ resource "time_sleep" "wait_30_seconds" {
 }
 
 module "associate_compute_nsg_wth_subnet" {
-  count                     = var.vpc_compute_cluster_private_subnets != null && local.compute_or_combined && length(setintersection(toset(coalesce(var.vpc_compute_cluster_private_subnets, ["none"])), toset(coalesce(var.vpc_storage_cluster_private_subnets, ["non"])))) == 0 ? length(var.vpc_compute_cluster_private_subnets) : 0
+  count                     = var.vpc_compute_cluster_private_subnets != null && local.compute_or_combined ? length(var.vpc_compute_cluster_private_subnets) : 0
   source                    = "../../../resources/azure/security/network_security_group_association"
   subnet_id                 = var.vpc_compute_cluster_private_subnets[count.index]
   network_security_group_id = module.scale_cluster_nsg.sec_group_id


### PR DESCRIPTION
[fix_ 1115, 1096] Fix same subnet assocation failure, dns combined and autoscale count unique
issue #1096 . [#1115](https://github.ibm.com/IBMSpectrumScale/scale-cloudkit/issues/1115)