### PR TITLE
Dns padding to avoid resource level conflict - issue #1148

### DIFF
--- a/azure_scale_templates/sub_modules/instance_template/main.tf
+++ b/azure_scale_templates/sub_modules/instance_template/main.tf
@@ -89,14 +89,14 @@ module "bastion_scale_cluster_tcp_inbound_security_rule" {
 module "storage_private_dns_zone" {
   source              = "../../../resources/azure/network/private_dns_zone"
   turn_on             = local.storage_or_combined == true ? true : false
-  dns_domain_name     = format("%s.%s", var.vpc_region, var.vpc_storage_cluster_dns_domain)
+  dns_domain_name     = format("%s.%s-%s", var.vpc_region, basename(var.vpc_ref), var.vpc_storage_cluster_dns_domain)
   resource_group_name = var.resource_group_ref
 }
 
 module "compute_private_dns_zone" {
   source              = "../../../resources/azure/network/private_dns_zone"
   turn_on             = var.cluster_type == "Compute-only" ? true : false
-  dns_domain_name     = format("%s.%s", var.vpc_region, var.vpc_compute_cluster_dns_domain)
+  dns_domain_name     = format("%s.%s-%s", var.vpc_region, basename(var.vpc_ref), var.vpc_compute_cluster_dns_domain)
   resource_group_name = var.resource_group_ref
 }
 
@@ -156,7 +156,7 @@ module "compute_cluster_instances" {
   user_key_pair                 = var.create_remote_mount_cluster == true ? var.compute_cluster_key_pair : var.storage_cluster_key_pair
   meta_private_key              = var.create_remote_mount_cluster == true ? module.generate_compute_cluster_keys.private_key_content : module.generate_storage_cluster_keys.private_key_content
   meta_public_key               = var.create_remote_mount_cluster == true ? module.generate_compute_cluster_keys.public_key_content : module.generate_storage_cluster_keys.public_key_content
-  dns_zone                      = format("%s.%s", var.vpc_region, var.vpc_compute_cluster_dns_domain)
+  dns_zone                      = format("%s.%s-%s", var.vpc_region, basename(var.vpc_ref), var.vpc_compute_cluster_dns_domain)
   availability_zone             = each.value["zone"]
   application_security_group_id = module.scale_cluster_asg.asg_id
   depends_on                    = [module.compute_private_dns_zone, module.storage_private_dns_zone]
@@ -188,7 +188,7 @@ module "storage_cluster_instances" {
   user_key_pair                  = var.storage_cluster_key_pair
   meta_private_key               = module.generate_storage_cluster_keys.private_key_content
   meta_public_key                = module.generate_storage_cluster_keys.public_key_content
-  dns_zone                       = format("%s.%s", var.vpc_region, var.vpc_storage_cluster_dns_domain)
+  dns_zone                       = format("%s.%s-%s", var.vpc_region, basename(var.vpc_ref), var.vpc_storage_cluster_dns_domain)
   availability_zone              = each.value["zone"]
   disks                          = each.value["disks"]
   application_security_group_id  = module.scale_cluster_asg.asg_id
@@ -213,7 +213,7 @@ module "storage_cluster_tie_breaker_instance" {
   user_key_pair                  = var.storage_cluster_key_pair
   meta_private_key               = module.generate_storage_cluster_keys.private_key_content
   meta_public_key                = module.generate_storage_cluster_keys.public_key_content
-  dns_zone                       = format("%s.%s", var.vpc_region, var.vpc_storage_cluster_dns_domain)
+  dns_zone                       = format("%s.%s-%s", var.vpc_region, basename(var.vpc_ref), var.vpc_storage_cluster_dns_domain)
   availability_zone              = each.value["zone"]
   disks                          = each.value["disks"]
   application_security_group_id  = module.scale_cluster_asg.asg_id


### PR DESCRIPTION
Dns padding to avoid resource level conflict
issue #1148


**Testing**
? Cluster name:  prvn-dnsconf01
? Are you operating cloudkit in air-gapped or no-internet environment:  No
? VPC Mode:  New
? IBM Storage Scale deployment model:  Storage-only
? Tuning profile:  Throughput-Performance-Persistent-Storage
? Region: eastus
? Azure Resource Group:  prvn-bal21
? Availability Zones (1):  1
? VPC CIDR:  10.0.0.0/16
? Do you wish to continue by creation of public subnet(s):  Yes
? IP address(s) in each subnet:  256
I: Calculated public subnet cidr(s): [10.0.0.0/24]
I: Calculated private (meant for storage nodes) subnet cidr(s): [10.0.1.0/24]
? Bastion OS:  CentOS | OpenLogic | 8_5-gen2
? Bastion/JumpHost instance login username:  azureuser
? Bastion instance type:  Standard_B2ls_v2  | vCPU(2)   | RAM (4.0 GB)  | Credits/hr (60)
? Bastion/Jumphost SSH private key file path (will be used only for configuration):  /root/.ssh/id_rsa
? Bastion IP address allow list:  170.225.223.16
? Select existing Image:  Select this option for custom input.
? Storage Image:  scale-image-32df6b0fd48040c1
? Storage instance login username:  azureuser
? Storage instance type:  Standard_D2d_v4   | vCPU(2)   | RAM (8.0 GB)   | Expected network bandwidth (5000  Mbps)
? Key pair to be used for launching Storage host instance(s):  prvn-bal21-bastion-key
? Storage node count:  4
? Filesystem mount point:  /gpfs/fs1
? Filesystem block size:  4M
? Filesystem capacity (Gi):  200Gi
? Storage cluster management GUI username:  administrator
? Storage cluster management GUI password:  [? for help] ***********
? Disk type:  Standard_LRS
? Do you wish to view cost before provisioning the resources (this requires infracost api_key):  No
I: To create this cluster again in the future, you can run: 
	cloudkit create cluster --airgap=false --region eastus --cloud-platform Azure --resource-name prvn-dnsconf01 --resource-grp-ref prvn-bal21 --client-id 4a81ee24-5f02-4066-b3b7-2d6ada265894 --tenant-id fcf67057-50c9-4ad4-98f3-ffca64add9e9 --subscription-id 5cd3cd6f-667b-4a89-a046-de077806c368 --gpfs-rpms /usr/lpp/mmfs/5.2.0.0 --avail-zones "1" --vpc-type New --deployment-mode Storage-only --network-mode JumpHost --profile-name Throughput-Performance-Persistent-Storage --create-public-subnets --ip-count-subnet 256 --view-cost=false --fs-mount-point /gpfs/fs1 --fs-block-size 4M --fs-capacity 200Gi --strg-gui-username administrator --operator-email None --vol-type Standard_LRS --vpc-cidr "10.0.0.0/16" --jumphost-login-user azureuser --jumphost-instance-type Standard_B2ls_v2 --jumphost-key-pair prvn-bal21-bastion-key --jumphost-private-key-path /root/.ssh/id_rsa --jumphost-ingress-cidr "170.225.223.16" --config-dns=false --create-dns=false --strg-image-ref /subscriptions/5cd3cd6f-667b-4a89-a046-de077806c368/resourceGroups/PRVN-DEVLAB/providers/Microsoft.Compute/images/scale-image-32df6b0fd48040c1 --strg-ins-type Standard_D2d_v4 --strg-ins-keypair prvn-bal21-bastion-key --strg-node-count 4 --instance-login-user azureuser --is-stock-image=false

I: Initiating resource provisioning actions proposed in the network IaC plan.
 100% |███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (2/10, 3 it/min)         
I: Network resource provisioning actions proposed in the plan completed.

I: Initiating resource provisioning actions proposed in the jumphost IaC plan.
 100% |█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (2/10, 24 it/hr)           
I: JumpHost resource provisioning actions proposed in the plan completed.

I: Initiating resource provisioning actions proposed in the scale instances IaC plan.
 100% |█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (2/10, 27 it/hr)           
I: Cluster resource provisioning actions proposed in the plan completed.

I: Waiting for instances to obtain running state.