### PR TITLE
Added lifecycle to gcp vm creation and update pre-commit to use tofu

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
   rev: v2.0.4
   hooks:
     - id: autopep8
-- repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.83.4
+- repo: https://github.com/tofuutils/pre-commit-opentofu
+  rev: v1.0.2
   hooks:
-    - id: terraform_fmt
-    - id: terraform_validate
-    - id: terraform_tflint
+    - id: tofu_fmt
+    - id: tofu_validate
+    - id: tofu_tflint
       args:
           - '--args=--only=terraform_deprecated_interpolation'
           - '--args=--only=terraform_deprecated_index'
@@ -30,7 +30,7 @@ repos:
           - '--args=--only=terraform_module_pinned_source'
           - '--args=--only=terraform_naming_convention'
           - '--args=--only=terraform_workspace_remote'
-    - id: terraform_tfsec
+    - id: tofu_tfsec
 - repo: local
   hooks:
     - id: custom-terraform-docs

--- a/resources/gcp/compute/vm_instance_0_disk/vm_instance_0_disk.tf
+++ b/resources/gcp/compute/vm_instance_0_disk/vm_instance_0_disk.tf
@@ -88,6 +88,9 @@ resource "google_compute_instance" "itself" {
     email  = var.service_email
     scopes = var.scopes
   }
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 # Add the VM instance ip as 'A' record to DNS


### PR DESCRIPTION
- Add lifecycle block to create VM in gcp.
- Updated the pre-commit to use tofu.

@sasikeda please review and merge.