### PR TITLE
IBMCloud improvements on vpc peering, storage volume attachments, orchestrator url inputs

### DIFF
--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/main.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/main.tf
@@ -120,4 +120,7 @@ module "scale_instances" {
   enable_placement_group                   = var.enable_placement_group
   placement_group_strategy                 = var.placement_group_strategy
   orchestrator_server                      = var.orchestrator_server
+  orchestrator_port                        = var.orchestrator_port
+  orchestrator_protocol                    = var.orchestrator_protocol
+  attach_storage_volumes                   = var.attach_storage_volumes
 }

--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/main.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/main.tf
@@ -122,5 +122,4 @@ module "scale_instances" {
   orchestrator_server                      = var.orchestrator_server
   orchestrator_port                        = var.orchestrator_port
   orchestrator_protocol                    = var.orchestrator_protocol
-  attach_storage_volumes                   = var.attach_storage_volumes
 }

--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/variables.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/variables.tf
@@ -182,6 +182,12 @@ variable "storage_volume_iops" {
   description = "IOPS for unattached storage volumes. Only applicable for custom IOPS profiles."
 }
 
+variable "attach_storage_volumes" {
+  type        = bool
+  default     = false
+  description = "If true, the provisioned storage volumes will be attached to the storage cluster instances via ibm_is_instance_volume_attachment."
+}
+
 variable "storage_cluster_public_key" {
   type        = string
   default     = null
@@ -338,5 +344,22 @@ variable "tags" {
 
 variable "orchestrator_server" {
   type        = string
-  description = "IP or hostname of the scale-orchestrator server running on the OCP worker node, e.g. 10.x.x.x. Injected as http://<value>:57096 into /etc/scale-agent/config.yaml on each VM at first boot."
+  description = "IP or hostname of the scale-orchestrator server, e.g. 10.x.x.x."
+}
+
+variable "orchestrator_port" {
+  type        = number
+  default     = 57096
+  description = "TCP port the scale-agent connects to on the orchestrator server."
+}
+
+variable "orchestrator_protocol" {
+  type        = string
+  default     = "http"
+  description = "Protocol used to reach the orchestrator server. Must be 'http' or 'https'."
+
+  validation {
+    condition     = contains(["http", "https"], var.orchestrator_protocol)
+    error_message = "orchestrator_protocol must be either 'http' or 'https'."
+  }
 }

--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/variables.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/variables.tf
@@ -182,12 +182,6 @@ variable "storage_volume_iops" {
   description = "IOPS for unattached storage volumes. Only applicable for custom IOPS profiles."
 }
 
-variable "attach_storage_volumes" {
-  type        = bool
-  default     = false
-  description = "If true, the provisioned storage volumes will be attached to the storage cluster instances via ibm_is_instance_volume_attachment."
-}
-
 variable "storage_cluster_public_key" {
   type        = string
   default     = null

--- a/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
@@ -201,7 +201,7 @@ module "storage_cluster_instances" {
   ssh_key_id                        = try(ibm_is_ssh_key.storage_ssh_key[0].id, null)
   vpc_id                            = var.vpc_id
   zone                              = each.value["zone"]
-  attach_volumes                    = var.attach_storage_volumes
+  attach_volumes                    = true
   orchestrator_server               = var.orchestrator_server
   orchestrator_port                 = var.orchestrator_port
   orchestrator_protocol             = var.orchestrator_protocol

--- a/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
@@ -176,6 +176,8 @@ module "compute_cluster_instances" {
   vpc_id                            = var.vpc_id
   zone                              = var.vpc_availability_zones
   orchestrator_server               = var.orchestrator_server
+  orchestrator_port                 = var.orchestrator_port
+  orchestrator_protocol             = var.orchestrator_protocol
 }
 
 module "storage_cluster_instances" {
@@ -199,8 +201,10 @@ module "storage_cluster_instances" {
   ssh_key_id                        = try(ibm_is_ssh_key.storage_ssh_key[0].id, null)
   vpc_id                            = var.vpc_id
   zone                              = each.value["zone"]
-  attach_volumes                    = false
+  attach_volumes                    = var.attach_storage_volumes
   orchestrator_server               = var.orchestrator_server
+  orchestrator_port                 = var.orchestrator_port
+  orchestrator_protocol             = var.orchestrator_protocol
 }
 
 module "storage_cluster_tie_breaker_instance" {
@@ -226,6 +230,8 @@ module "storage_cluster_tie_breaker_instance" {
   zone                              = each.value["zone"]
   attach_volumes                    = true
   orchestrator_server               = var.orchestrator_server
+  orchestrator_port                 = var.orchestrator_port
+  orchestrator_protocol             = var.orchestrator_protocol
 }
 
 module "protocol_instances" {
@@ -270,4 +276,6 @@ module "gateway_instances" {
   vpc_id                            = var.vpc_id
   zone                              = var.vpc_availability_zones
   orchestrator_server               = var.orchestrator_server
+  orchestrator_port                 = var.orchestrator_port
+  orchestrator_protocol             = var.orchestrator_protocol
 }

--- a/ibmcloud_scale_templates/sub_modules/instance_template/variables.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/variables.tf
@@ -192,6 +192,12 @@ variable "storage_volume_iops" {
   description = "IOPS for unattached storage volumes."
 }
 
+variable "attach_storage_volumes" {
+  type        = bool
+  default     = false
+  description = "If true, the provisioned storage volumes will be attached to the storage cluster instances via ibm_is_instance_volume_attachment."
+}
+
 variable "compute_cluster_image_id" {
   type        = string
   default     = "ibm-redhat-8-3-minimal-amd64-3"
@@ -274,7 +280,24 @@ variable "root_device_kms_key_name" {
 
 variable "orchestrator_server" {
   type        = string
-  description = "IP or hostname of the scale-orchestrator server, e.g. 10.x.x.x. Injected as http://<value>:57096 into /etc/scale-agent/config.yaml on each VM at first boot."
+  description = "IP or hostname of the scale-orchestrator server, e.g. 10.x.x.x."
+}
+
+variable "orchestrator_port" {
+  type        = number
+  default     = 57096
+  description = "TCP port the scale-agent connects to on the orchestrator server."
+}
+
+variable "orchestrator_protocol" {
+  type        = string
+  default     = "http"
+  description = "Protocol used to reach the orchestrator server. Must be 'http' or 'https'."
+
+  validation {
+    condition     = contains(["http", "https"], var.orchestrator_protocol)
+    error_message = "orchestrator_protocol must be either 'http' or 'https'."
+  }
 }
 
 variable "enable_placement_group" {

--- a/ibmcloud_scale_templates/sub_modules/instance_template/variables.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/variables.tf
@@ -192,12 +192,6 @@ variable "storage_volume_iops" {
   description = "IOPS for unattached storage volumes."
 }
 
-variable "attach_storage_volumes" {
-  type        = bool
-  default     = false
-  description = "If true, the provisioned storage volumes will be attached to the storage cluster instances via ibm_is_instance_volume_attachment."
-}
-
 variable "compute_cluster_image_id" {
   type        = string
   default     = "ibm-redhat-8-3-minimal-amd64-3"

--- a/ibmcloud_scale_templates/sub_modules/vpc_peering_template/README.md
+++ b/ibmcloud_scale_templates/sub_modules/vpc_peering_template/README.md
@@ -7,6 +7,7 @@ This Terraform sub-module provisions IBM Cloud Transit Gateway resources to enab
 The VPC peering template creates:
 - **Transit Gateway**: Central hub for connecting multiple VPCs (optional - can use existing)
 - **VPC Connections**: Attachments for new and peer VPCs to Transit Gateway
+- **Duplicate Connection Prevention**: Automatically detects if peer VPC is already attached to existing Transit Gateway
 - **Global Routing**: Optional cross-region connectivity support
 
 ## Purpose
@@ -16,6 +17,7 @@ This module provides network connectivity between VPCs for Spectrum Scale:
 - Enable multi-region deployments with global routing
 - Centralized network management through Transit Gateway
 - Secure private network communication between VPCs
+- **Smart duplicate detection**: Prevents creating duplicate connections when peer VPC is already attached to the Transit Gateway
 
 ## Prerequisites
 
@@ -84,7 +86,7 @@ Connect a newly created VPC with an existing peer VPC using a new Transit Gatewa
 
 ### Example 2: Use Existing Transit Gateway
 
-Connect VPCs to an existing Transit Gateway instead of creating a new one.
+Connect VPCs to an existing Transit Gateway instead of creating a new one. The module will automatically check if the peer VPC is already attached to the Transit Gateway and skip creating a duplicate connection.
 
 ```jsonc
 {
@@ -95,9 +97,15 @@ Connect VPCs to an existing Transit Gateway instead of creating a new one.
     "peer_vpc_crn": "crn:v1:bluemix:public:is:REGION:a/ACCOUNT_ID::vpc:PEER_VPC_ID",
     "resource_prefix": "scale-prod",
     "resource_group_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-    "existing_transit_gateway_name": "existing-transit-gateway-name"
+    "transit_gateway_name": "existing-transit-gateway-name"
 }
 ```
+
+**Note**: When using an existing Transit Gateway, the module automatically checks if the peer VPC is already connected. If it is, the module will:
+- Skip creating a duplicate connection
+- Set `peer_vpc_already_attached` output to `true`
+- Set `peer_vpc_connection_status` output to `"existing"`
+- Return the existing connection ID in `peer_vpc_connection_id` output
 
 ### Example 3: Global Routing for Cross-Region Connectivity
 
@@ -151,6 +159,7 @@ Connect only the new VPC to Transit Gateway without a peer VPC.
 - Required for multi-region deployments
 - Additional charges apply for cross-region data transfer
 
+
 ## Outputs
 
 After deployment, the following outputs are available:
@@ -165,6 +174,8 @@ terraform output transit_gateway_crn
 terraform output transit_gateway_name
 terraform output new_vpc_connection_id
 terraform output peer_vpc_connection_id
+terraform output peer_vpc_already_attached
+terraform output peer_vpc_connection_status
 terraform output transit_gateway_status
 ```
 
@@ -211,7 +222,9 @@ terraform destroy -auto-approve
 | Name | Description |
 | ---- | ----------- |
 | <a name="output_new_vpc_connection_id"></a> [new_vpc_connection_id](#output_new_vpc_connection_id) | ID of the Transit Gateway connection for the new VPC. |
-| <a name="output_peer_vpc_connection_id"></a> [peer_vpc_connection_id](#output_peer_vpc_connection_id) | ID of the Transit Gateway connection for the peer VPC. |
+| <a name="output_peer_vpc_connection_id"></a> [peer_vpc_connection_id](#output_peer_vpc_connection_id) | ID of the Transit Gateway connection for the peer VPC (either existing or newly created). |
+| <a name="output_peer_vpc_already_attached"></a> [peer_vpc_already_attached](#output_peer_vpc_already_attached) | Boolean flag indicating if the peer VPC was already attached to the Transit Gateway. |
+| <a name="output_peer_vpc_connection_status"></a> [peer_vpc_connection_status](#output_peer_vpc_connection_status) | Status of peer VPC connection: 'existing' (already attached), 'created' (newly attached), or 'not_configured' (no peer VPC specified). |
 | <a name="output_transit_gateway_crn"></a> [transit_gateway_crn](#output_transit_gateway_crn) | CRN of the Transit Gateway (either existing or newly created). |
 | <a name="output_transit_gateway_id"></a> [transit_gateway_id](#output_transit_gateway_id) | ID of the Transit Gateway (either existing or newly created). |
 | <a name="output_transit_gateway_name"></a> [transit_gateway_name](#output_transit_gateway_name) | Name of the Transit Gateway. |

--- a/ibmcloud_scale_templates/sub_modules/vpc_peering_template/locals.tf
+++ b/ibmcloud_scale_templates/sub_modules/vpc_peering_template/locals.tf
@@ -5,4 +5,16 @@ locals {
   # Determine which Transit Gateway to use
   transit_gateway_id  = var.transit_gateway_name != null ? try(data.ibm_tg_gateway.existing[0].id, null) : try(ibm_tg_gateway.new[0].id, null)
   transit_gateway_crn = var.transit_gateway_name != null ? try(data.ibm_tg_gateway.existing[0].crn, null) : try(ibm_tg_gateway.new[0].crn, null)
+
+  # Check if peer VPC is already attached to the existing Transit Gateway
+  # This prevents duplicate connections when using an existing transit gateway
+  existing_peer_vpc_connections = var.transit_gateway_name != null && var.peer_vpc_crn != null ? [
+    for conn in try(data.ibm_tg_gateway.existing[0].connections, []) :
+    conn if conn.network_id == var.peer_vpc_crn
+  ] : []
+
+  peer_vpc_already_attached = length(local.existing_peer_vpc_connections) > 0
+
+  # Get the existing peer VPC connection ID if it exists
+  existing_peer_vpc_connection_id = local.peer_vpc_already_attached ? local.existing_peer_vpc_connections[0].id : null
 }

--- a/ibmcloud_scale_templates/sub_modules/vpc_peering_template/main.tf
+++ b/ibmcloud_scale_templates/sub_modules/vpc_peering_template/main.tf
@@ -37,9 +37,9 @@ resource "ibm_tg_connection" "new_vpc" {
   network_id   = var.vpc_crn
 }
 
-# Attach the peer VPC to Transit Gateway
+# Attach the peer VPC to Transit Gateway only if not already attached
 resource "ibm_tg_connection" "peer_vpc" {
-  count        = var.peer_vpc_crn != null ? local.create_count : 0
+  count        = var.peer_vpc_crn != null && !local.peer_vpc_already_attached ? local.create_count : 0
   gateway      = local.transit_gateway_id
   network_type = "vpc"
   name         = "${var.resource_prefix}-peer-vpc-connection"

--- a/ibmcloud_scale_templates/sub_modules/vpc_peering_template/outputs.tf
+++ b/ibmcloud_scale_templates/sub_modules/vpc_peering_template/outputs.tf
@@ -19,8 +19,18 @@ output "new_vpc_connection_id" {
 }
 
 output "peer_vpc_connection_id" {
-  value       = try(ibm_tg_connection.peer_vpc[0].id, null)
-  description = "ID of the Transit Gateway connection for the peer VPC."
+  value       = local.peer_vpc_already_attached ? local.existing_peer_vpc_connection_id : try(ibm_tg_connection.peer_vpc[0].id, null)
+  description = "ID of the Transit Gateway connection for the peer VPC (either existing or newly created)."
+}
+
+output "peer_vpc_already_attached" {
+  value       = local.peer_vpc_already_attached
+  description = "Boolean flag indicating if the peer VPC was already attached to the Transit Gateway."
+}
+
+output "peer_vpc_connection_status" {
+  value       = local.peer_vpc_already_attached ? "existing" : (var.peer_vpc_crn != null ? "created" : "not_configured")
+  description = "Status of peer VPC connection: 'existing' (already attached), 'created' (newly attached), or 'not_configured' (no peer VPC specified)."
 }
 
 output "transit_gateway_status" {

--- a/resources/ibmcloud/compute/vsi_0_vol/vsi_0_vol.tf
+++ b/resources/ibmcloud/compute/vsi_0_vol/vsi_0_vol.tf
@@ -28,6 +28,12 @@ variable "dns_service_instance_id" {}
 variable "dns_domain" {}
 variable "resource_group_id" {}
 variable "orchestrator_server" {}
+variable "orchestrator_port" {
+  default = 57096
+}
+variable "orchestrator_protocol" {
+  default = "http"
+}
 
 # Resolves the CRN of your KMS key for boot volume encryption
 data "ibm_kms_key" "itself" {
@@ -69,7 +75,7 @@ resource "ibm_is_instance" "itself" {
 #!/usr/bin/env bash
 hostnamectl set-hostname --static "${var.name_prefix}.${var.dns_domain}"
 echo "${var.name_prefix}.${var.dns_domain}" > /etc/hostname
-sed -i "s|^server_url:.*|server_url: http://${var.orchestrator_server}:57096|" /etc/scale-agent/config.yaml
+sed -i "s|^server_url:.*|server_url: ${var.orchestrator_protocol}://${var.orchestrator_server}:${var.orchestrator_port}|" /etc/scale-agent/config.yaml
 systemctl restart scale-agent
 EOF
 

--- a/resources/ibmcloud/compute/vsi_multiple_vol/vsi_multiple_vol.tf
+++ b/resources/ibmcloud/compute/vsi_multiple_vol/vsi_multiple_vol.tf
@@ -31,6 +31,12 @@ variable "vpc_id" {}
 variable "attach_volumes" {}
 variable "resource_group_id" {}
 variable "orchestrator_server" {}
+variable "orchestrator_port" {
+  default = 57096
+}
+variable "orchestrator_protocol" {
+  default = "http"
+}
 
 # Resolves the CRN of your KMS key for boot volume encryption
 data "ibm_kms_key" "itself" {
@@ -74,7 +80,7 @@ resource "ibm_is_instance" "itself" {
 #!/usr/bin/env bash
 hostnamectl set-hostname --static "${var.name_prefix}.${var.dns_domain}"
 echo "${var.name_prefix}.${var.dns_domain}" > /etc/hostname
-sed -i "s|^server_url:.*|server_url: http://${var.orchestrator_server}:57096|" /etc/scale-agent/config.yaml
+sed -i "s|^server_url:.*|server_url: ${var.orchestrator_protocol}://${var.orchestrator_server}:${var.orchestrator_port}|" /etc/scale-agent/config.yaml
 systemctl restart scale-agent
 EOF
 


### PR DESCRIPTION
1. Updated the vpc peering templates to check if the peer VPC is already attached to the Transit Gateway and skip creating a duplicate connection.
2. Added the storage volume attachements to the VSI instances.
3. Added input variables to pass the protocol and port for the orchestrator url