### PR TITLE
fix: pass orchestrator URL to protocol nodes and default orchestrator port to https

### DIFF
--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/main.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/main.tf
@@ -121,5 +121,4 @@ module "scale_instances" {
   placement_group_strategy                 = var.placement_group_strategy
   orchestrator_server                      = var.orchestrator_server
   orchestrator_port                        = var.orchestrator_port
-  orchestrator_protocol                    = var.orchestrator_protocol
 }

--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/variables.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/variables.tf
@@ -347,13 +347,3 @@ variable "orchestrator_port" {
   description = "TCP port the scale-agent connects to on the orchestrator server."
 }
 
-variable "orchestrator_protocol" {
-  type        = string
-  default     = "http"
-  description = "Protocol used to reach the orchestrator server. Must be 'http' or 'https'."
-
-  validation {
-    condition     = contains(["http", "https"], var.orchestrator_protocol)
-    error_message = "orchestrator_protocol must be either 'http' or 'https'."
-  }
-}

--- a/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
@@ -177,7 +177,6 @@ module "compute_cluster_instances" {
   zone                              = var.vpc_availability_zones
   orchestrator_server               = var.orchestrator_server
   orchestrator_port                 = var.orchestrator_port
-  orchestrator_protocol             = var.orchestrator_protocol
 }
 
 module "storage_cluster_instances" {
@@ -204,7 +203,6 @@ module "storage_cluster_instances" {
   attach_volumes                    = true
   orchestrator_server               = var.orchestrator_server
   orchestrator_port                 = var.orchestrator_port
-  orchestrator_protocol             = var.orchestrator_protocol
 }
 
 module "storage_cluster_tie_breaker_instance" {
@@ -231,7 +229,6 @@ module "storage_cluster_tie_breaker_instance" {
   attach_volumes                    = true
   orchestrator_server               = var.orchestrator_server
   orchestrator_port                 = var.orchestrator_port
-  orchestrator_protocol             = var.orchestrator_protocol
 }
 
 module "protocol_instances" {
@@ -254,6 +251,8 @@ module "protocol_instances" {
   ssh_key_id                        = try(ibm_is_ssh_key.storage_ssh_key[0].id, null)
   vpc_id                            = var.vpc_id
   zone                              = each.value["zone"]
+  orchestrator_server               = var.orchestrator_server
+  orchestrator_port                 = var.orchestrator_port
 }
 
 module "gateway_instances" {
@@ -277,5 +276,4 @@ module "gateway_instances" {
   zone                              = var.vpc_availability_zones
   orchestrator_server               = var.orchestrator_server
   orchestrator_port                 = var.orchestrator_port
-  orchestrator_protocol             = var.orchestrator_protocol
 }

--- a/ibmcloud_scale_templates/sub_modules/instance_template/variables.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/variables.tf
@@ -283,16 +283,6 @@ variable "orchestrator_port" {
   description = "TCP port the scale-agent connects to on the orchestrator server."
 }
 
-variable "orchestrator_protocol" {
-  type        = string
-  default     = "http"
-  description = "Protocol used to reach the orchestrator server. Must be 'http' or 'https'."
-
-  validation {
-    condition     = contains(["http", "https"], var.orchestrator_protocol)
-    error_message = "orchestrator_protocol must be either 'http' or 'https'."
-  }
-}
 
 variable "enable_placement_group" {
   type        = bool

--- a/resources/ibmcloud/compute/vsi_0_vol/vsi_0_vol.tf
+++ b/resources/ibmcloud/compute/vsi_0_vol/vsi_0_vol.tf
@@ -28,9 +28,7 @@ variable "dns_service_instance_id" {}
 variable "dns_domain" {}
 variable "resource_group_id" {}
 variable "orchestrator_server" {}
-variable "orchestrator_port" {
-  default = 57096
-}
+variable "orchestrator_port" {}
 # Resolves the CRN of your KMS key for boot volume encryption
 data "ibm_kms_key" "itself" {
   count       = var.root_device_kms_key_instance_id != null && var.root_device_kms_key_instance_name != null ? 1 : 0

--- a/resources/ibmcloud/compute/vsi_0_vol/vsi_0_vol.tf
+++ b/resources/ibmcloud/compute/vsi_0_vol/vsi_0_vol.tf
@@ -31,10 +31,6 @@ variable "orchestrator_server" {}
 variable "orchestrator_port" {
   default = 57096
 }
-variable "orchestrator_protocol" {
-  default = "http"
-}
-
 # Resolves the CRN of your KMS key for boot volume encryption
 data "ibm_kms_key" "itself" {
   count       = var.root_device_kms_key_instance_id != null && var.root_device_kms_key_instance_name != null ? 1 : 0
@@ -75,7 +71,7 @@ resource "ibm_is_instance" "itself" {
 #!/usr/bin/env bash
 hostnamectl set-hostname --static "${var.name_prefix}.${var.dns_domain}"
 echo "${var.name_prefix}.${var.dns_domain}" > /etc/hostname
-sed -i "s|^server_url:.*|server_url: ${var.orchestrator_protocol}://${var.orchestrator_server}:${var.orchestrator_port}|" /etc/scale-agent/config.yaml
+sed -i "s|^server_url:.*|server_url: https://${var.orchestrator_server}:${var.orchestrator_port}|" /etc/scale-agent/config.yaml
 systemctl restart scale-agent
 EOF
 

--- a/resources/ibmcloud/compute/vsi_ip_fwd/vsi_ip_fwd.tf
+++ b/resources/ibmcloud/compute/vsi_ip_fwd/vsi_ip_fwd.tf
@@ -28,7 +28,10 @@ variable "dns_service_instance_id" {}
 variable "dns_domain" {}
 variable "vpc_id" {}
 variable "resource_group_id" {}
-
+variable "orchestrator_server" {}
+variable "orchestrator_port" {
+  default = 57096
+}
 # Create a Service ID for CES automation (equivalent to AWS IAM Role)
 resource "ibm_iam_service_id" "ces_automation" {
   name        = "${var.name_prefix}-ces-automation"
@@ -86,6 +89,8 @@ resource "ibm_is_instance" "itself" {
 #!/usr/bin/env bash
 hostnamectl set-hostname --static "${var.name_prefix}.${var.dns_domain}"
 echo "${var.name_prefix}.${var.dns_domain}" > /etc/hostname
+sed -i "s|^server_url:.*|server_url: https://${var.orchestrator_server}:${var.orchestrator_port}|" /etc/scale-agent/config.yaml
+systemctl restart scale-agent
 EOF
 
   metadata_service {

--- a/resources/ibmcloud/compute/vsi_ip_fwd/vsi_ip_fwd.tf
+++ b/resources/ibmcloud/compute/vsi_ip_fwd/vsi_ip_fwd.tf
@@ -29,9 +29,7 @@ variable "dns_domain" {}
 variable "vpc_id" {}
 variable "resource_group_id" {}
 variable "orchestrator_server" {}
-variable "orchestrator_port" {
-  default = 57096
-}
+variable "orchestrator_port" {}
 # Create a Service ID for CES automation (equivalent to AWS IAM Role)
 resource "ibm_iam_service_id" "ces_automation" {
   name        = "${var.name_prefix}-ces-automation"

--- a/resources/ibmcloud/compute/vsi_multiple_vol/vsi_multiple_vol.tf
+++ b/resources/ibmcloud/compute/vsi_multiple_vol/vsi_multiple_vol.tf
@@ -31,9 +31,7 @@ variable "vpc_id" {}
 variable "attach_volumes" {}
 variable "resource_group_id" {}
 variable "orchestrator_server" {}
-variable "orchestrator_port" {
-  default = 57096
-}
+variable "orchestrator_port" {}
 # Resolves the CRN of your KMS key for boot volume encryption
 data "ibm_kms_key" "itself" {
   count       = var.root_device_kms_key_instance_id != null && var.root_device_kms_key_instance_name != null ? 1 : 0

--- a/resources/ibmcloud/compute/vsi_multiple_vol/vsi_multiple_vol.tf
+++ b/resources/ibmcloud/compute/vsi_multiple_vol/vsi_multiple_vol.tf
@@ -34,10 +34,6 @@ variable "orchestrator_server" {}
 variable "orchestrator_port" {
   default = 57096
 }
-variable "orchestrator_protocol" {
-  default = "http"
-}
-
 # Resolves the CRN of your KMS key for boot volume encryption
 data "ibm_kms_key" "itself" {
   count       = var.root_device_kms_key_instance_id != null && var.root_device_kms_key_instance_name != null ? 1 : 0
@@ -80,7 +76,7 @@ resource "ibm_is_instance" "itself" {
 #!/usr/bin/env bash
 hostnamectl set-hostname --static "${var.name_prefix}.${var.dns_domain}"
 echo "${var.name_prefix}.${var.dns_domain}" > /etc/hostname
-sed -i "s|^server_url:.*|server_url: ${var.orchestrator_protocol}://${var.orchestrator_server}:${var.orchestrator_port}|" /etc/scale-agent/config.yaml
+sed -i "s|^server_url:.*|server_url: https://${var.orchestrator_server}:${var.orchestrator_port}|" /etc/scale-agent/config.yaml
 systemctl restart scale-agent
 EOF
 


### PR DESCRIPTION
To update the orchestrator url in the protocol node with the passed orchestrator details and also to default the orchestrator port to https.