### PR TITLE
feat: add orchestrator_ca_fingerprint to update /etc/scale-agent/config.yaml

### DIFF
--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/main.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/main.tf
@@ -121,4 +121,5 @@ module "scale_instances" {
   placement_group_strategy                 = var.placement_group_strategy
   orchestrator_server                      = var.orchestrator_server
   orchestrator_port                        = var.orchestrator_port
+  orchestrator_ca_fingerprint              = var.orchestrator_ca_fingerprint
 }

--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/variables.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/variables.tf
@@ -347,3 +347,9 @@ variable "orchestrator_port" {
   description = "TCP port the scale-agent connects to on the orchestrator server."
 }
 
+variable "orchestrator_ca_fingerprint" {
+  type        = string
+  sensitive   = true
+  description = "SHA-256 fingerprint of the orchestrator's CA certificate, used to authenticate the agent-to-orchestrator TLS connection. Expected format: 'SHA256 Fingerprint=XX:XX:...:XX'."
+}
+

--- a/ibmcloud_scale_templates/sub_modules/instance_template/locals.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/locals.tf
@@ -7,7 +7,7 @@ locals {
   create_placement_group = length(var.vpc_availability_zones) == 1 && var.enable_placement_group
 
   # Internode scale firewall ports
-  tcp_port_scale_cluster = ["22", "1191", "47080", "4444", "4739", "9080", "9081", "80", "443"]
+  tcp_port_scale_cluster = ["22", "1191", "47080", "4444", "4739", "9080", "9081", "80", "443", "50052"]
   udp_port_scale_cluster = ["47443", "4739"]
 
   # GPFS ephemeral RPC port range used for internode daemon traffic

--- a/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
@@ -177,6 +177,7 @@ module "compute_cluster_instances" {
   zone                              = var.vpc_availability_zones
   orchestrator_server               = var.orchestrator_server
   orchestrator_port                 = var.orchestrator_port
+  orchestrator_ca_fingerprint       = var.orchestrator_ca_fingerprint
 }
 
 module "storage_cluster_instances" {
@@ -203,6 +204,7 @@ module "storage_cluster_instances" {
   attach_volumes                    = true
   orchestrator_server               = var.orchestrator_server
   orchestrator_port                 = var.orchestrator_port
+  orchestrator_ca_fingerprint       = var.orchestrator_ca_fingerprint
 }
 
 module "storage_cluster_tie_breaker_instance" {
@@ -229,6 +231,7 @@ module "storage_cluster_tie_breaker_instance" {
   attach_volumes                    = true
   orchestrator_server               = var.orchestrator_server
   orchestrator_port                 = var.orchestrator_port
+  orchestrator_ca_fingerprint       = var.orchestrator_ca_fingerprint
 }
 
 module "protocol_instances" {
@@ -253,6 +256,7 @@ module "protocol_instances" {
   zone                              = each.value["zone"]
   orchestrator_server               = var.orchestrator_server
   orchestrator_port                 = var.orchestrator_port
+  orchestrator_ca_fingerprint       = var.orchestrator_ca_fingerprint
 }
 
 module "gateway_instances" {
@@ -276,4 +280,5 @@ module "gateway_instances" {
   zone                              = var.vpc_availability_zones
   orchestrator_server               = var.orchestrator_server
   orchestrator_port                 = var.orchestrator_port
+  orchestrator_ca_fingerprint       = var.orchestrator_ca_fingerprint
 }

--- a/ibmcloud_scale_templates/sub_modules/instance_template/variables.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/variables.tf
@@ -283,6 +283,11 @@ variable "orchestrator_port" {
   description = "TCP port the scale-agent connects to on the orchestrator server."
 }
 
+variable "orchestrator_ca_fingerprint" {
+  type        = string
+  sensitive   = true
+  description = "SHA-256 fingerprint of the orchestrator's CA certificate. Expected format: 'SHA256 Fingerprint=XX:XX:...:XX'."
+}
 
 variable "enable_placement_group" {
   type        = bool

--- a/resources/ibmcloud/compute/vsi_0_vol/vsi_0_vol.tf
+++ b/resources/ibmcloud/compute/vsi_0_vol/vsi_0_vol.tf
@@ -29,6 +29,7 @@ variable "dns_domain" {}
 variable "resource_group_id" {}
 variable "orchestrator_server" {}
 variable "orchestrator_port" {}
+variable "orchestrator_ca_fingerprint" {}
 # Resolves the CRN of your KMS key for boot volume encryption
 data "ibm_kms_key" "itself" {
   count       = var.root_device_kms_key_instance_id != null && var.root_device_kms_key_instance_name != null ? 1 : 0
@@ -70,6 +71,7 @@ resource "ibm_is_instance" "itself" {
 hostnamectl set-hostname --static "${var.name_prefix}.${var.dns_domain}"
 echo "${var.name_prefix}.${var.dns_domain}" > /etc/hostname
 sed -i "s|^server_url:.*|server_url: https://${var.orchestrator_server}:${var.orchestrator_port}|" /etc/scale-agent/config.yaml
+sed -i "s|^ca_fingerprint:.*|ca_fingerprint: \"${var.orchestrator_ca_fingerprint}\"|" /etc/scale-agent/config.yaml
 systemctl restart scale-agent
 EOF
 

--- a/resources/ibmcloud/compute/vsi_ip_fwd/vsi_ip_fwd.tf
+++ b/resources/ibmcloud/compute/vsi_ip_fwd/vsi_ip_fwd.tf
@@ -30,6 +30,7 @@ variable "vpc_id" {}
 variable "resource_group_id" {}
 variable "orchestrator_server" {}
 variable "orchestrator_port" {}
+variable "orchestrator_ca_fingerprint" {}
 # Create a Service ID for CES automation (equivalent to AWS IAM Role)
 resource "ibm_iam_service_id" "ces_automation" {
   name        = "${var.name_prefix}-ces-automation"
@@ -88,6 +89,7 @@ resource "ibm_is_instance" "itself" {
 hostnamectl set-hostname --static "${var.name_prefix}.${var.dns_domain}"
 echo "${var.name_prefix}.${var.dns_domain}" > /etc/hostname
 sed -i "s|^server_url:.*|server_url: https://${var.orchestrator_server}:${var.orchestrator_port}|" /etc/scale-agent/config.yaml
+sed -i "s|^ca_fingerprint:.*|ca_fingerprint: \"${var.orchestrator_ca_fingerprint}\"|" /etc/scale-agent/config.yaml
 systemctl restart scale-agent
 EOF
 

--- a/resources/ibmcloud/compute/vsi_multiple_vol/vsi_multiple_vol.tf
+++ b/resources/ibmcloud/compute/vsi_multiple_vol/vsi_multiple_vol.tf
@@ -32,6 +32,7 @@ variable "attach_volumes" {}
 variable "resource_group_id" {}
 variable "orchestrator_server" {}
 variable "orchestrator_port" {}
+variable "orchestrator_ca_fingerprint" {}
 # Resolves the CRN of your KMS key for boot volume encryption
 data "ibm_kms_key" "itself" {
   count       = var.root_device_kms_key_instance_id != null && var.root_device_kms_key_instance_name != null ? 1 : 0
@@ -75,6 +76,7 @@ resource "ibm_is_instance" "itself" {
 hostnamectl set-hostname --static "${var.name_prefix}.${var.dns_domain}"
 echo "${var.name_prefix}.${var.dns_domain}" > /etc/hostname
 sed -i "s|^server_url:.*|server_url: https://${var.orchestrator_server}:${var.orchestrator_port}|" /etc/scale-agent/config.yaml
+sed -i "s|^ca_fingerprint:.*|ca_fingerprint: \"${var.orchestrator_ca_fingerprint}\"|" /etc/scale-agent/config.yaml
 systemctl restart scale-agent
 EOF
 


### PR DESCRIPTION
1. To pass the orchestrator_ca_fingerprint generated in the orchestrator/controller node and use it in scale agent config for registration.
