### PR TITLE
ibmcloud: fix public subnet, expose volume/node ids, add protocol outputs

### DIFF
--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/outputs.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/outputs.tf
@@ -199,6 +199,16 @@ output "storage_cluster_desc_data_volume_mapping" {
   description = "Mapping of storage cluster desc instance ip vs. device path."
 }
 
+output "protocol_cluster_instance_ids" {
+  value       = [for inst in try(module.scale_instances.protocol_instance_details, []) : inst.id]
+  description = "Protocol cluster instance ids."
+}
+
+output "protocol_cluster_instance_private_ips" {
+  value       = [for inst in try(module.scale_instances.protocol_instance_details, []) : inst.private_ip]
+  description = "Private IP address of protocol cluster instances."
+}
+
 output "placement_group_id" {
   value       = try(module.scale_instances.placement_group_id, null)
   description = "IBM Cloud placement group id for single-AZ deployments."
@@ -237,4 +247,14 @@ output "nodes" {
       role     = "protocol"
     }]
   )
+}
+
+output "storage_cluster_volume_ids" {
+  value       = try(module.scale_instances.storage_cluster_volume_ids, {})
+  description = "Map of disk-key to volume ID for all storage cluster data volumes."
+}
+
+output "storage_cluster_desc_volume_ids" {
+  value       = try(module.scale_instances.storage_cluster_desc_volume_ids, {})
+  description = "Map of disk-key to volume ID for storage cluster tiebreaker data volumes."
 }

--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/variables.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/variables.tf
@@ -88,8 +88,9 @@ variable "vpc_protocol_private_subnets_cidr_blocks" {
 
 variable "vpc_public_subnets_cidr_blocks" {
   type        = list(string)
-  default     = ["10.241.3.0/24", "10.241.66.0/24", "10.241.130.0/24"]
-  description = "List of CIDR blocks for public subnets, one per availability zone. Set to empty array [] if no public subnets are needed."
+  nullable    = true
+  default     = null
+  description = "List of CIDR blocks for public subnets, one per availability zone. Leave null (default) when no bastion host is deployed — skips public subnet and public gateway creation entirely."
 }
 
 variable "dns_service_instance_id" {

--- a/ibmcloud_scale_templates/sub_modules/instance_template/outputs.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/outputs.tf
@@ -110,3 +110,13 @@ output "storage_vm_zone_map" {
 output "storage_instance_ips_with_disk_mapping" {
   value = local.storage_instance_ips_with_disk_mapping
 }
+
+output "storage_cluster_volume_ids" {
+  value       = merge([for instance in module.storage_cluster_instances : instance.volume_ids]...)
+  description = "Flat map of disk-key to volume ID for all storage cluster data volumes."
+}
+
+output "storage_cluster_desc_volume_ids" {
+  value       = merge([for instance in module.storage_cluster_tie_breaker_instance : instance.volume_ids]...)
+  description = "Flat map of disk-key to volume ID for storage cluster tiebreaker data volumes."
+}

--- a/ibmcloud_scale_templates/sub_modules/vpc_template/locals.tf
+++ b/ibmcloud_scale_templates/sub_modules/vpc_template/locals.tf
@@ -21,6 +21,6 @@ locals {
   is_compute_cluster = contains(["Compute-only", "Combined-compute-storage"], var.cluster_type)
 
   # Feature flags
-  enable_public_subnets  = var.vpc_public_subnets_cidr_blocks != null
+  enable_public_subnets  = var.vpc_public_subnets_cidr_blocks != null && length(var.vpc_public_subnets_cidr_blocks) > 0
   enable_protocol_subnet = local.is_storage_cluster && var.vpc_protocol_private_subnets_cidr_blocks != null
 }

--- a/resources/ibmcloud/compute/vsi_multiple_vol/vsi_multiple_vol.tf
+++ b/resources/ibmcloud/compute/vsi_multiple_vol/vsi_multiple_vol.tf
@@ -137,3 +137,8 @@ output "instance_details" {
     zone       = ibm_is_instance.itself.zone
   }
 }
+
+output "volume_ids" {
+  value       = { for k, v in ibm_is_volume.itself : "${var.name_prefix}-${k}" => v.id }
+  description = "Map of '<instance>-<disk-key>' to volume ID for volumes attached to this instance."
+}

--- a/resources/ibmcloud/network/subnet/subnet.tf
+++ b/resources/ibmcloud/network/subnet/subnet.tf
@@ -30,7 +30,7 @@ resource "ibm_is_subnet" "itself" {
   resource_group  = var.resource_group_id
   zone            = element(var.zones, count.index)
   ipv4_cidr_block = element(var.subnets_cidr, count.index)
-  public_gateway  = element(var.public_gateway, count.index)
+  public_gateway  = length(var.public_gateway) > 0 ? element(var.public_gateway, count.index) : null
   tags            = var.tags
 }
 


### PR DESCRIPTION
1.  Expose cloud resource IDs in terraform output - https://jazz07.rchland.ibm.com:21443/jazz/web/projects/GPFS#action=com.ibm.team.workitem.viewWorkItem&id=373835

2.  Public subnet is made optional and defaulted to null - https://jazz07.rchland.ibm.com:21443/jazz/web/projects/GPFS#action=com.ibm.team.workitem.viewWorkItem&id=373838