### PR TITLE
feat(ibmcloud): add total_volume_bandwidth support for storage and protocol nodes

### DIFF
--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/main.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/main.tf
@@ -99,6 +99,9 @@ module "scale_instances" {
   storage_volume_size                      = var.storage_volume_size
   storage_volume_profile                   = var.storage_volume_profile
   storage_volume_iops                      = var.storage_volume_iops
+  storage_volume_mbps                      = var.storage_volume_mbps
+  storage_vol_bandwidth                    = var.storage_vol_bandwidth
+  protocol_vol_bandwidth                   = var.protocol_vol_bandwidth
   total_compute_cluster_instances          = var.total_compute_cluster_instances
   compute_cluster_image_id                 = var.compute_vsi_osimage_id
   compute_cluster_instance_type            = var.compute_vsi_profile

--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/variables.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/variables.tf
@@ -183,6 +183,28 @@ variable "storage_volume_iops" {
   description = "IOPS for unattached storage volumes. Only applicable for custom IOPS profiles."
 }
 
+variable "storage_volume_mbps" {
+  type        = number
+  default     = null
+  description = "Throughput (Mbps) per attached storage volume. Used to compute storage_vol_bandwidth when not explicitly set: storage_vol_bandwidth = (vols_per_vsi * storage_volume_mbps) + 393. Leave null to use IBM Cloud's default bandwidth allocation."
+}
+
+variable "storage_vol_bandwidth" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Bandwidth (Mbps) reserved for volume I/O on each NSD VSI.
+    Default when null: (vols_per_vsi * storage_volume_mbps) + 393.
+    When set explicitly, overrides the formula.
+  EOT
+}
+
+variable "protocol_vol_bandwidth" {
+  type        = number
+  default     = 800
+  description = "Bandwidth (Mbps) reserved for volume I/O on each protocol/CES VSI. Default 800 Mbps."
+}
+
 variable "storage_cluster_public_key" {
   type        = string
   default     = null

--- a/ibmcloud_scale_templates/sub_modules/instance_template/locals.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/locals.tf
@@ -130,3 +130,21 @@ locals {
     }
   }
 }
+
+locals {
+  # Effective storage volume bandwidth passed to each NSD VSI.
+  # Priority: explicit user input (storage_vol_bandwidth) > formula > null (50/50 profile default in vsi_multiple_vol.tf).
+  # Formula: (vols_per_vsi * storage_volume_mbps) + 393
+  effective_storage_vol_bandwidth = (
+    var.storage_vol_bandwidth != null
+    ? var.storage_vol_bandwidth
+    : (
+        var.storage_volume_mbps != null && local.disks_per_vm > 0
+        ? (local.disks_per_vm * var.storage_volume_mbps) + 393
+        : null
+      )
+  )
+
+  # Protocol nodes: user input or default 800 Mbps.
+  effective_protocol_vol_bandwidth = var.protocol_vol_bandwidth
+}

--- a/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
@@ -202,6 +202,7 @@ module "storage_cluster_instances" {
   vpc_id                            = var.vpc_id
   zone                              = each.value["zone"]
   attach_volumes                    = true
+  total_volume_bandwidth            = local.effective_storage_vol_bandwidth
   orchestrator_server               = var.orchestrator_server
   orchestrator_port                 = var.orchestrator_port
   orchestrator_ca_fingerprint       = var.orchestrator_ca_fingerprint
@@ -229,6 +230,7 @@ module "storage_cluster_tie_breaker_instance" {
   vpc_id                            = var.vpc_id
   zone                              = each.value["zone"]
   attach_volumes                    = true
+  total_volume_bandwidth            = null
   orchestrator_server               = var.orchestrator_server
   orchestrator_port                 = var.orchestrator_port
   orchestrator_ca_fingerprint       = var.orchestrator_ca_fingerprint
@@ -250,6 +252,7 @@ module "protocol_instances" {
   security_groups                   = var.using_jumphost_connection && var.bastion_security_group_id != null ? [module.cluster_security_group.sec_group_id, module.protocol_security_group.sec_group_id, var.bastion_security_group_id] : [module.cluster_security_group.sec_group_id, module.protocol_security_group.sec_group_id]
   subnet_id                         = each.value["subnet"]
   ces_ipaddress                     = each.value["ces_ip_addresses"]
+  total_volume_bandwidth            = local.effective_protocol_vol_bandwidth
   tags                              = var.tags
   ssh_key_id                        = try(ibm_is_ssh_key.storage_ssh_key[0].id, null)
   vpc_id                            = var.vpc_id

--- a/ibmcloud_scale_templates/sub_modules/instance_template/variables.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/variables.tf
@@ -192,6 +192,36 @@ variable "storage_volume_iops" {
   description = "IOPS for unattached storage volumes."
 }
 
+variable "storage_volume_mbps" {
+  type        = number
+  nullable    = true
+  default     = null
+  description = "Throughput (Mbps) per attached storage volume. Used to compute storage_vol_bandwidth when not explicitly set: storage_vol_bandwidth = (vols_per_vsi * storage_volume_mbps) + 393. Leave null to use IBM Cloud's default bandwidth allocation."
+
+  validation {
+    condition     = var.storage_volume_mbps == null || var.storage_volume_mbps >= 1
+    error_message = "storage_volume_mbps must be a positive integer or null."
+  }
+}
+
+variable "storage_vol_bandwidth" {
+  type        = number
+  nullable    = true
+  default     = null
+  description = <<-EOT
+    Bandwidth (Mbps) reserved for volume I/O on each NSD VSI.
+    Default when null: (vols_per_vsi * storage_volume_mbps) + 393.
+    When set explicitly, overrides the formula.
+  EOT
+}
+
+variable "protocol_vol_bandwidth" {
+  type        = number
+  nullable    = true
+  default     = 800
+  description = "Bandwidth (Mbps) reserved for volume I/O on each protocol/CES VSI. Default 800 Mbps."
+}
+
 variable "compute_cluster_image_id" {
   type        = string
   default     = "ibm-redhat-8-3-minimal-amd64-3"

--- a/resources/ibmcloud/compute/vsi_ip_fwd/vsi_ip_fwd.tf
+++ b/resources/ibmcloud/compute/vsi_ip_fwd/vsi_ip_fwd.tf
@@ -31,6 +31,7 @@ variable "resource_group_id" {}
 variable "orchestrator_server" {}
 variable "orchestrator_port" {}
 variable "orchestrator_ca_fingerprint" {}
+variable "total_volume_bandwidth" {}
 # Create a Service ID for CES automation (equivalent to AWS IAM Role)
 resource "ibm_iam_service_id" "ces_automation" {
   name        = "${var.name_prefix}-ces-automation"
@@ -71,6 +72,10 @@ resource "ibm_is_instance" "itself" {
 
   vpc  = var.vpc_id
   zone = var.zone
+
+  # Reserve Mbps for volume I/O on protocol/CES nodes (default 800 Mbps).
+  # IBM Cloud automatically assigns the remainder to the NIC.
+  total_volume_bandwidth = var.total_volume_bandwidth
 
   primary_network_interface {
     subnet          = var.subnet_id

--- a/resources/ibmcloud/compute/vsi_multiple_vol/vsi_multiple_vol.tf
+++ b/resources/ibmcloud/compute/vsi_multiple_vol/vsi_multiple_vol.tf
@@ -33,6 +33,8 @@ variable "resource_group_id" {}
 variable "orchestrator_server" {}
 variable "orchestrator_port" {}
 variable "orchestrator_ca_fingerprint" {}
+variable "total_volume_bandwidth" {}
+
 # Resolves the CRN of your KMS key for boot volume encryption
 data "ibm_kms_key" "itself" {
   count       = var.root_device_kms_key_instance_id != null && var.root_device_kms_key_instance_name != null ? 1 : 0
@@ -53,6 +55,10 @@ resource "ibm_is_instance" "itself" {
 
   # Assign to placement group if provided
   placement_group = var.placement_group
+
+  # Reserve Mbps for volume I/O. IBM Cloud automatically assigns the remainder
+  # to the NIC as total_network_bandwidth (Computed-only — cannot be set explicitly).
+  total_volume_bandwidth = var.total_volume_bandwidth
 
   primary_network_interface {
     subnet          = var.subnet_id


### PR DESCRIPTION
- Add storage_vol_bandwidth and protocol_vol_bandwidth as user inputs
- Add storage_volume_mbps input for per-volume throughput driven formula:
  storage_vol_bandwidth = (vols_per_vsi * storage_volume_mbps) + 393