### PR TITLE
ibmcloud: add instance id->name maps for storage/protocol nodes, fix volume_ids merge on empty cluster

### DIFF
--- a/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/outputs.tf
+++ b/ibmcloud_scale_templates/ibmcloud_new_vpc_scale/outputs.tf
@@ -209,6 +209,16 @@ output "protocol_cluster_instance_private_ips" {
   description = "Private IP address of protocol cluster instances."
 }
 
+output "storage_cluster_instance_id_name_map" {
+  value       = try(module.scale_instances.storage_cluster_instance_id_name_map, {})
+  description = "Map of storage cluster instance ID to DNS hostname."
+}
+
+output "protocol_cluster_instance_id_name_map" {
+  value       = try(module.scale_instances.protocol_cluster_instance_id_name_map, {})
+  description = "Map of protocol cluster instance ID to DNS hostname."
+}
+
 output "placement_group_id" {
   value       = try(module.scale_instances.placement_group_id, null)
   description = "IBM Cloud placement group id for single-AZ deployments."

--- a/ibmcloud_scale_templates/sub_modules/instance_template/outputs.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/outputs.tf
@@ -111,12 +111,22 @@ output "storage_instance_ips_with_disk_mapping" {
   value = local.storage_instance_ips_with_disk_mapping
 }
 
+output "storage_cluster_instance_id_name_map" {
+  value       = { for instance in module.storage_cluster_instances : instance.instance_details.id => instance.instance_details.dns }
+  description = "Map of storage cluster instance ID to DNS hostname."
+}
+
+output "protocol_cluster_instance_id_name_map" {
+  value       = { for instance in module.protocol_instances : instance.instance_details.id => instance.instance_details.dns }
+  description = "Map of protocol cluster instance ID to DNS hostname."
+}
+
 output "storage_cluster_volume_ids" {
-  value       = merge([for instance in module.storage_cluster_instances : instance.volume_ids]...)
+  value       = length(module.storage_cluster_instances) > 0 ? merge([for instance in module.storage_cluster_instances : instance.volume_ids]...) : {}
   description = "Flat map of disk-key to volume ID for all storage cluster data volumes."
 }
 
 output "storage_cluster_desc_volume_ids" {
-  value       = merge([for instance in module.storage_cluster_tie_breaker_instance : instance.volume_ids]...)
+  value       = length(module.storage_cluster_tie_breaker_instance) > 0 ? merge([for instance in module.storage_cluster_tie_breaker_instance : instance.volume_ids]...) : {}
   description = "Flat map of disk-key to volume ID for storage cluster tiebreaker data volumes."
 }


### PR DESCRIPTION
- Adds `storage_cluster_instance_id_name_map` and `protocol_cluster_instance_id_name_map` outputs that provide an instance ID → FQDN mapping for storage and protocol node
- Fixes `storage_cluster_volume_ids` which was silently absent from terraform output due to a plan-time type inference failure on the bare merge([for ...]...) expression when the instance map is empty