### PR TITLE
Expose grafana-bridge port 9250

### DIFF
--- a/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
+++ b/ibmcloud_scale_templates/sub_modules/instance_template/main.tf
@@ -79,6 +79,11 @@ module "scale_cluster_ingress_security_rule_using_direct_connection" {
       protocol = "tcp"
       port_min = 46443
       port_max = 46443
+    }],
+    [{
+      protocol = "tcp"
+      port_min = 9250
+      port_max = 9250
     }]
   )
 }


### PR DESCRIPTION
Allow inbound traffic to port 9250 for grafana-bridge, sourced from the configured client ip range. 